### PR TITLE
Alphabetical sorting

### DIFF
--- a/docs/controls/alertdialog.md
+++ b/docs/controls/alertdialog.md
@@ -68,27 +68,25 @@ ft.app(target=main)
 
 ## Properties
 
-### `open`
+### `actions`
 
-Set to `True` to display a dialog.
+The (optional) set of actions that are displayed at the bottom of the dialog.
 
-### `modal`
+Typically this is a list of [`TextButton`](textbutton) controls.
 
-Whether dialog can be dismissed by clicking the area outside of it.
+### `actions_alignment`
 
-### `title`
+Defines the horizontal layout of the actions according to the same rules as for [`Row.alignment`](row#alignment).
 
-The (optional) title of the dialog is displayed in a large font at the top of the dialog.
+Property value is `MainAxisAlignment` enum with `MainAxisAlignment.END` as default.
 
-Typically a [`Text`](text) control.
+### `actions_padding`
 
-### `title_padding`
+Padding around the set of actions at the bottom of the dialog.
 
-Padding around the title.
+Typically used to provide padding to the button bar between the button bar and the edges of the dialog.
 
-If there is no title, no padding will be provided. Otherwise, this padding is used.
-
-This property defaults to providing 24 pixels on the top, left, and right of the title. If the content is not null, then no bottom padding is provided (but see `content_padding`). If it is not set, then an extra 20 pixels of bottom padding is added to separate the title from the actions.
+If are no actions, then no padding will be included. The padding around the button bar defaults to zero.
 
 See [`Container.padding`](container#padding) for more information about padding and possible values.
 
@@ -104,27 +102,13 @@ If there is no content, no padding will be provided. Otherwise, padding of 20 pi
 
 See [`Container.padding`](container#padding) for more information about padding and possible values.
 
-### `actions`
+### `modal`
 
-The (optional) set of actions that are displayed at the bottom of the dialog.
+Whether dialog can be dismissed by clicking the area outside of it.
 
-Typically this is a list of [`TextButton`](textbutton) controls.
+### `open`
 
-### `actions_padding`
-
-Padding around the set of actions at the bottom of the dialog.
-
-Typically used to provide padding to the button bar between the button bar and the edges of the dialog.
-
-If are no actions, then no padding will be included. The padding around the button bar defaults to zero.
-
-See [`Container.padding`](container#padding) for more information about padding and possible values.
-
-### `actions_alignment`
-
-Defines the horizontal layout of the actions according to the same rules as for [`Row.alignment`](row#alignment).
-
-Property value is `MainAxisAlignment` enum with `MainAxisAlignment.END` as default.
+Set to `True` to display a dialog.
 
 ### `shape`
 
@@ -141,6 +125,22 @@ The value is an instance of one of the following implementations:
     * `radius` - border radius, an instance of `BorderRadius` class or a number.
 
 The default shape is a `RoundedRectangleBorder` with a radius of 4.0.
+
+### `title`
+
+The (optional) title of the dialog is displayed in a large font at the top of the dialog.
+
+Typically a [`Text`](text) control.
+
+### `title_padding`
+
+Padding around the title.
+
+If there is no title, no padding will be provided. Otherwise, this padding is used.
+
+This property defaults to providing 24 pixels on the top, left, and right of the title. If the content is not null, then no bottom padding is provided (but see `content_padding`). If it is not set, then an extra 20 pixels of bottom padding is added to separate the title from the actions.
+
+See [`Container.padding`](container#padding) for more information about padding and possible values.
 
 ## Events
 

--- a/docs/controls/appbar.md
+++ b/docs/controls/appbar.md
@@ -55,6 +55,36 @@ ft.app(target=main)
 
 ## Properties
 
+### `actions`
+
+A list of `Control`s to display in a row after the title control.
+
+Typically these controls are [`IconButtons`](iconbutton) representing common operations. For less common operations, consider using a [`PopupMenuButton`](popupmenubutton) as the last action.
+
+### `automatically_imply_leading`
+
+Controls whether we should try to imply the leading widget if null.
+
+If `True` and `leading` is null, automatically try to deduce what the leading widget should be. If `False` and `leading` is null, leading space is given to title. If leading widget is not null, this parameter has no effect.
+
+### `bgcolor`
+
+The fill color to use for an AppBar. Default color is defined by current theme.
+
+### `center_title`
+
+Whether the title should be centered. Default is `False`.
+
+### `color`
+
+The default color for Text and Icons within the app bar. Default color is defined by current theme.
+
+### `elevation`
+
+This property controls the size of the shadow below the app bar. Default value is 4.
+
+Note: This effect is only visible when using the Material 2 design (when `Theme.use_material3=False`).
+
 ### `leading`
 
 A `Control` to display before the toolbar's title.
@@ -69,36 +99,6 @@ Defines the width of leading control. By default, the value of `leading_width` i
 
 The primary `Control` displayed in the app bar. Typically a [`Text`](text) control that contains a description of the current contents of the app.
 
-### `center_title`
-
-Whether the title should be centered. Default is `False`.
-
-### `actions`
-
-A list of `Control`s to display in a row after the title control.
-
-Typically these controls are [`IconButtons`](iconbutton) representing common operations. For less common operations, consider using a [`PopupMenuButton`](popupmenubutton) as the last action.
-
 ### `toolbar_height`
 
 Defines the height of the toolbar component of an AppBar. By default, the value of `toolbar_height` is `56.0`.
-
-### `color`
-
-The default color for Text and Icons within the app bar. Default color is defined by current theme.
-
-### `bgcolor`
-
-The fill color to use for an AppBar. Default color is defined by current theme.
-
-### `elevation`
-
-This property controls the size of the shadow below the app bar. Default value is 4.
-
-Note: This effect is only visible when using the Material 2 design (when `Theme.use_material3=False`).
-
-### `automatically_imply_leading`
-
-Controls whether we should try to imply the leading widget if null.
-
-If `True` and `leading` is null, automatically try to deduce what the leading widget should be. If `False` and `leading` is null, leading space is given to title. If leading widget is not null, this parameter has no effect.

--- a/docs/controls/audio.md
+++ b/docs/controls/audio.md
@@ -114,14 +114,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `src`
-
-Sets the URL to the audio file. It could be an asset URL, see [Image.src](/docs/controls/image#src) for more information about assets.
-
-### `src_base64`
-
-Sets the contents of audio file encoded in base-64 format.
-
 ### `autoplay`
 
 Starts playing audio as soon as audio control is added to a page.
@@ -129,12 +121,6 @@ Starts playing audio as soon as audio control is added to a page.
 :::note
 Autoplay works in desktop, mobile apps and Safari browser, but doesn't work in Chrome/Edge.
 :::
-
-### `volume`
-
-Sets the volume (amplitude).
-
-0 is mute and 1 is the max volume. The values between 0 and 1 are linearly interpolated.
 
 ### `balance`
 
@@ -145,6 +131,14 @@ Sets the stereo balance.
 :::note
 Setting balance is supported on Windows and Linux only.
 :::
+
+### `get_current_position()`
+
+Returns the current position in milliseconds.
+
+### `get_duration()`
+
+Returns the duration of audio in milliseconds.
 
 ### `playback_rate`
 
@@ -158,24 +152,32 @@ Sets the release mode. The following values are supported:
 * `ReleaseMode.LOOP` - Keeps buffered data and plays again after completion, creating a loop. Notice that calling stop method is not enough to release the resources when this mode is being used.
 * `ReleaseMode.STOP` - Stops audio playback but keep all resources intact. Use this if you intend to play again later.
 
+### `src`
+
+Sets the URL to the audio file. It could be an asset URL, see [Image.src](/docs/controls/image#src) for more information about assets.
+
+### `src_base64`
+
+Sets the contents of audio file encoded in base-64 format.
+
 ## Methods
-
-### `play()`
-
-Starts playing audio for the beginning.
 
 ### `pause()`
 
 Stops playing audio.
 
-### `resume()`
+### `play()`
 
-Resumes playing audio from the current position.
+Starts playing audio for the beginning.
 
 ### `release()`
 
 Stops playing and releases the resources associated with this audio control.
 The resources are going to be fetched or buffered again as soon as you call `resume()` or change the source.
+
+### `resume()`
+
+Resumes playing audio from the current position.
 
 ### `seek()`
 
@@ -185,25 +187,31 @@ Method arguments:
 
 * `position_milliseconds` - desired position in milliseconds.
 
-### `get_duration()`
+### `volume`
 
-Returns the duration of audio in milliseconds.
+Sets the volume (amplitude).
 
-### `get_current_position()`
-
-Returns the current position in milliseconds.
+0 is mute and 1 is the max volume. The values between 0 and 1 are linearly interpolated.
 
 ## Events
-
-### `on_loaded`
-
-Fires when an audio is loaded/buffered.
 
 ### `on_duration_changed`
 
 Fires as soon as audio duration is available (it might take a while to download or buffer it).
 
 Event's `e.data` contains audio duration in milliseconds.
+
+### `on_loaded`
+
+Fires when an audio is loaded/buffered.
+
+### `on_position_changed`
+
+Fires when audio position is changed. Will continuously update the position of the playback every 1 second if the status is playing. Can be used for a progress bar.
+
+### `on_seek_complete`
+
+Fires on seek completions. An event is going to be sent as soon as the audio seek is finished.
 
 ### `on_state_changed`
 
@@ -213,11 +221,3 @@ Fires when audio player state changes. Event's `e.data` contains one of the foll
 * `playing`
 * `paused`
 * `completed`
-
-### `on_position_changed`
-
-Fires when audio position is changed. Will continuously update the position of the playback every 1 second if the status is playing. Can be used for a progress bar.
-
-### `on_seek_complete`
-
-Fires on seek completions. An event is going to be sent as soon as the audio seek is finished.

--- a/docs/controls/banner.md
+++ b/docs/controls/banner.md
@@ -54,19 +54,15 @@ ft.app(target=main)
 
 ## Properties
 
-### `open`
+### `actions`
 
-Set to `True` to display a banner.
+The set of actions that are displayed at the bottom or trailing side of the Banner.
 
-### `leading`
+Typically this is a list of [`TextButton`](textbutton) controls.
 
-The (optional) leading `Control` of the Banner.
+### `bgcolor`
 
-Typically an [`Icon`](icon) control.
-
-### `leading_padding`
-
-The amount of space by which to inset the leading control. This defaults to 16 virtual pixels. See [`Container.padding`](container#padding) for more information about padding and possible values.
+The color of the surface of this Banner.
 
 ### `content`
 
@@ -82,12 +78,6 @@ If the actions are trailing the content, this defaults to `padding.only(left=16.
 
 See [`Container.padding`](container#padding) for more information about padding and possible values.
 
-### `actions`
-
-The set of actions that are displayed at the bottom or trailing side of the Banner.
-
-Typically this is a list of [`TextButton`](textbutton) controls.
-
 ### `force_actions_below`
 
 An override to force the actions to be below the content regardless of how many there are.
@@ -96,6 +86,16 @@ If this is `True`, the actions will be placed below the content. If this is `Fal
 
 Defaults to `False`.
 
-### `bgcolor`
+### `leading`
 
-The color of the surface of this Banner.
+The (optional) leading `Control` of the Banner.
+
+Typically an [`Icon`](icon) control.
+
+### `leading_padding`
+
+The amount of space by which to inset the leading control. This defaults to 16 virtual pixels. See [`Container.padding`](container#padding) for more information about padding and possible values.
+
+### `open`
+
+Set to `True` to display a banner.

--- a/docs/controls/bottomsheet.md
+++ b/docs/controls/bottomsheet.md
@@ -51,16 +51,16 @@ ft.app(target=main)
 
 ## Properties
 
-### `open`
-
-Set to `True` to display a bottom sheet.
-
 ### `content`
 
 The content of the bottom sheet.
+
+### `open`
+
+Set to `True` to display a bottom sheet.
 
 ## Events
 
 ### `on_dismiss`
 
-Fires when bottom sheet is dimissed.
+Fires when bottom sheet is dismissed.

--- a/docs/controls/buttons.md
+++ b/docs/controls/buttons.md
@@ -20,10 +20,10 @@ export const ImageCard = ({title, href, imageUrl}) => (
     <ImageCard title="Elevated" href="/docs/controls/elevatedbutton" imageUrl="elevated-button.png" />
     <ImageCard title="Filled" href="/docs/controls/filledbutton" imageUrl="filled-button.png" />
     <ImageCard title="Filled Tonal" href="/docs/controls/filledtonalbutton" imageUrl="filled-tonal-button.png" />
-    <ImageCard title="Outlined" href="/docs/controls/outlinedbutton" imageUrl="outlined-button.png" />
-    <ImageCard title="Text Button" href="/docs/controls/textbutton" imageUrl="text-button.png" />
-    <ImageCard title="Icon Button" href="/docs/controls/iconbutton" imageUrl="icon-button.png" />
     <ImageCard title="Floating Action" href="/docs/controls/floatingactionbutton" imageUrl="floating-action-button.png" />
+    <ImageCard title="Icon Button" href="/docs/controls/iconbutton" imageUrl="icon-button.png" />
+    <ImageCard title="Outlined" href="/docs/controls/outlinedbutton" imageUrl="outlined-button.png" />
     <ImageCard title="Popup Menu" href="/docs/controls/popupmenubutton" imageUrl="popup-menu.gif" />
+    <ImageCard title="Text Button" href="/docs/controls/textbutton" imageUrl="text-button.png" />
   </section>
 </div>

--- a/docs/controls/card.md
+++ b/docs/controls/card.md
@@ -59,12 +59,12 @@ The `Control` that should be displayed inside the card.
 
 This control can only have one child. To lay out multiple children, let this control's child be a control such as [`Row`](row), [`Column`](column), or [`Stack`](stack), which have a children property, and then provide the children to that control.
 
+### `elevation`
+
+Controls the size of the shadow below the card. Default value is `1.0`.
+
 ### `margin`
 
 The empty space that surrounds the card.
 
 See [`Container.margin`](container#margin) property for more information and possible values.
-
-### `elevation`
-
-Controls the size of the shadow below the card. Default value is `1.0`.

--- a/docs/controls/checkbox.md
+++ b/docs/controls/checkbox.md
@@ -71,24 +71,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
-
-Current value of the checkbox.
-
-### `tristate`
-
-If `True` the checkbox's value can be `True`, `False`, or `None` (`null`).
-
-Checkbox displays a dash when its value is null.
-
-### `label`
-
-The clickable label to display on the right of a checkbox.
-
-### `label_position`
-
-Property value is `LabelPosition` enum with `LabelPosition.RIGHT` as default.
-
 ### `autofocus`
 
 True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
@@ -127,7 +109,29 @@ chk.fill_color={
 }
 ```
 
+### `label`
+
+The clickable label to display on the right of a checkbox.
+
+### `label_position`
+
+Property value is `LabelPosition` enum with `LabelPosition.RIGHT` as default.
+
+### `tristate`
+
+If `True` the checkbox's value can be `True`, `False`, or `None` (`null`).
+
+Checkbox displays a dash when its value is null.
+
+### `value`
+
+Current value of the checkbox.
+
 ## Events
+
+### `on_blur`
+
+Fires when the control has lost focus.
 
 ### `on_change`
 
@@ -136,7 +140,3 @@ Fires when the state of the Checkbox is changed.
 ### `on_focus`
 
 Fires when the control has received focus.
-
-### `on_blur`
-
-Fires when the control has lost focus.

--- a/docs/controls/circleavatar.md
+++ b/docs/controls/circleavatar.md
@@ -29,7 +29,7 @@ def main(page):
         foreground_image_url="https://avatars.githubusercontent.com/u/5041459?s=88&v=4",
         content=ft.Text("FF"),
     )
-    # avatar with failing foregroung image and fallback text
+    # avatar with failing foreground image and fallback text
     a2 = ft.CircleAvatar(
         foreground_image_url="https://avatars.githubusercontent.com/u/_5041459?s=88&v=4",
         content=ft.Text("FF"),
@@ -70,10 +70,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `foreground_image_url`
-
-The foreground image of the circle. Typically used as profile image. For fallback use `background_image_url`.
-
 ### `background_image_url`
 
 The background image of the circle. Changing the background image will cause the avatar to animate to the new image. Typically used as a fallback image for `foreground_image_url`. If the CircleAvatar is to have the user's initials, use `content` instead.
@@ -86,22 +82,26 @@ The color with which to fill the circle. Changing the background color will caus
 
 The default text color for text in the circle. Defaults to the primary text theme color if no `bgcolor` is specified.
 
-### `radius`
+### `content`
 
-The size of the avatar, expressed as the radius (half the diameter). If radius is specified, then neither minRadius nor maxRadius may be specified.
+Typically a `Text` control. If the CircleAvatar is to have an image, use `background_image_url` instead.
 
-### `min_radius`
+### `foreground_image_url`
 
-The minimum size of the avatar, expressed as the radius (half the diameter). If minRadius is specified, then radius must not also be specified. Defaults to zero.
+The foreground image of the circle. Typically used as profile image. For fallback use `background_image_url`.
 
 ### `max_radius`
 
 The maximum size of the avatar, expressed as the radius (half the diameter). If maxRadius is specified, then radius must not also be specified. Defaults to "infinity".
 
+### `min_radius`
+
+The minimum size of the avatar, expressed as the radius (half the diameter). If minRadius is specified, then radius must not also be specified. Defaults to zero.
+
+### `radius`
+
+The size of the avatar, expressed as the radius (half the diameter). If radius is specified, then neither minRadius nor maxRadius may be specified.
+
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `content`
-
-Typically a `Text` control. If the CircleAvatar is to have an image, use `background_image_url` instead.

--- a/docs/controls/column.md
+++ b/docs/controls/column.md
@@ -246,10 +246,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `controls`
-
-A list of Controls to display inside the Column.
-
 ### `alignment`
 
 How the child Controls should be placed vertically.
@@ -263,6 +259,14 @@ Property value is `MainAxisAlignment` enum with the following values:
 * `SPACE_AROUND`
 * `SPACE_EVENLY`
 
+### `auto_scroll`
+
+`True` if scrollbar should automatically move its position to the end when children update.
+
+### `controls`
+
+A list of Controls to display inside the Column.
+
 ### `horizontal_alignment`
 
 How the child Controls should be placed horizontally.
@@ -274,22 +278,6 @@ Property value is `CrossAxisAlignment` enum with the following values:
 * `END`
 * `STRETCH`
 * `BASELINE`
-
-### `tight`
-
-Specifies how much space should be occupied vertically. Default is `False` - allocate all space to children.
-
-### `spacing`
-
-Spacing between controls in a Column. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
-
-### `wrap`
-
-When set to `True` the Column will put child controls into additional columns (runs) if they don't fit a single column.
-
-### `run_spacing`
-
-Spacing between runs when `wrap=True`. Default value is 10.
 
 ### `scroll`
 
@@ -305,9 +293,21 @@ Supported values:
 * `ALWAYS` - scrolling is enabled and scroll bar is always shown.
 * `HIDDEN` - scrolling is enabled, but scroll bar is always hidden.
 
-### `auto_scroll`
+### `spacing`
 
-`True` if scrollbar should automatically move its position to the end when children update.
+Spacing between controls in a Column. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
+
+### `run_spacing`
+
+Spacing between runs when `wrap=True`. Default value is 10.
+
+### `tight`
+
+Specifies how much space should be occupied vertically. Default is `False` - allocate all space to children.
+
+### `wrap`
+
+When set to `True` the Column will put child controls into additional columns (runs) if they don't fit a single column.
 
 ## Expanding children
 

--- a/docs/controls/container.md
+++ b/docs/controls/container.md
@@ -128,53 +128,6 @@ ft.app(target=main)
 
 <img src="/img/docs/controls/container/container-diagram.png" className="screenshot-50" />
 
-### `content`
-
-A child Control contained by the container.
-
-### `padding`
-
-Empty space to inscribe inside a container decoration (background, border). The child control is placed inside this padding.
-
-Padding is an instance of `padding.Padding` class with properties set padding for all sides of the rectangle: `left`, `top`, `right`, `bottom`. An instance of `padding.Padding` can be created via constructor with values for specific sides or created with helper methods:
-
-* `padding.all(value: float)`
-* `padding.symmetric(vertical, horizontal)`
-* `padding.only(left, top, right, bottom)`
-
-For example:
-
-```python
-
-container_1.padding = ft.padding.all(10)
-container_2.padding = 20 # same as ft.padding.all(20)
-container_3.padding = ft.padding.symmetric(horizontal=10)
-container_4.padding=padding.only(left=10)
-```
-
-<img src="/img/docs/controls/container/container-padding-diagram.png" className="screenshot-50" />
-
-### `margin`
-
-Empty space to surround the decoration and child control.
-
-Margin is an instance of `margin.Margin` class with properties set margins for all sides of the rectangle: `left`, `top`, `right`, `bottom`. An instance of `margin.Margin` can be created via constructor with values for specific sides or created with helper methods:
-
-* `margin.all(value)`
-* `margin.symmetric(vertical, horizontal)`
-* `margin.only(left, top, right, bottom)`
-
-For example:
-
-```python
-
-container_1.margin = margin.all(10)
-container_2.margin = 20 # same as margin.all(20)
-container_3.margin = margin.symmetric(vertical=10)
-container_3.margin = margin.only(left=10)
-```
-<img src="/img/docs/controls/container/container-margin-diagram.png" className="screenshot-50" />
-
 ### `alignment`
 
 Align the child control within the container.
@@ -193,11 +146,52 @@ container_3.alignment = alignment.Alignment(-0.5, -0.5)
 ```
 <img src="/img/docs/controls/container/containers-alignments.png" className="screenshot-50" />
 
+### `animate`
+
+Enables container "implicit" animation that gradually changes its values over a period of time.
+
+The value of `animate` property could be one of the following types:
+
+* `bool` - `True` to enable container animation with `linear` curve with `1000` milliseconds duration.
+* `int` - enable container animation with `linear` curve and specified number of milliseconds. 
+* `animation.Animation(duration: int, curve: str)` - enable container animation with specified duration and transition curve.
+
+For example:
+
+<img src="/img/docs/controls/container/animate-container.gif" className="screenshot-20" />
+
+```python
+import flet as ft
+
+def main(page: ft.Page):
+
+    c = ft.Container(
+        width=200,
+        height=200,
+        bgcolor="red",
+        animate=ft.animation.Animation(1000, "bounceOut"),
+    )
+
+    def animate_container(e):
+        c.width = 100 if c.width == 200 else 200
+        c.height = 100 if c.height == 200 else 200
+        c.bgcolor = "blue" if c.bgcolor == "red" else "red"
+        c.update()
+
+    page.add(c, ft.ElevatedButton("Animate container", on_click=animate_container))
+
+ft.app(target=main)
+```
+
 ### `bgcolor`
 
 Background color of the container.
 
 A color value could be a hex value in `#ARGB` format (e.g. `#FFCC0000`), `#RGB` format (e.g. `#CC0000`) or a named color from `flet.colors` module.
+
+### `blend_mode`
+
+The blend mode applied to the `color` or `gradient` background of the container. See [`ShaderMask.blend_mode`](shadermask#blend_mode) for more details.
 
 ### `border`
 
@@ -231,12 +225,20 @@ For example:
 container_1.border_radius= ft.border_radius.all(30)
 ```
 
-### `shape`
+### `clip_behavior`
 
-Sets the shape of the container. The value is `BoxShape` enum:
+The content will be clipped (or not) according to this option.
 
-* `RECTANGLE` (default)
-* `CIRCLE`
+Property value is `ClipBehavior` enum with supported values:
+
+* `NONE` (default)
+* `ANTI_ALIAS`
+* `ANTI_ALIAS_WITH_SAVE_LAYER`
+* `HARD_EDGE`
+
+### `content`
+
+A child Control contained by the container.
 
 ### `gradient`
 
@@ -333,18 +335,6 @@ More information:
 
 * [Sweep gradient](https://api.flutter.dev/flutter/painting/SweepGradient-class.html) in Flutter documentation.
 
-### `image_src`
-
-Sets an image as a container background. See [`Image.src`](image#src) for more details.
-
-### `image_src_base64`
-
-Sets an image encoded as Base-64 string as a container background. See [`Image.src_base64`](image#src_base64) for more details.
-
-### `image_repeat`
-
-See [`Image.repeat`](image#repeat) for more details.
-
 ### `image_fit`
 
 See [`Image.fit`](image#fit) for more details.
@@ -353,61 +343,71 @@ See [`Image.fit`](image#fit) for more details.
 
 Sets image opacity when blending with a background: value between `0.0` and `1.0`.
 
-### `blend_mode`
+### `image_repeat`
 
-The blend mode applied to the `color` or `gradient` background of the container. See [`ShaderMask.blend_mode`](shadermask#blend_mode) for more details.
+See [`Image.repeat`](image#repeat) for more details.
 
-### `animate`
+### `image_src`
 
-Enables container "implicit" animation that gradually changes its values over a period of time.
+Sets an image as a container background. See [`Image.src`](image#src) for more details.
 
-The value of `animate` property could be one of the following types:
+### `image_src_base64`
 
-* `bool` - `True` to enable container animation with `linear` curve with `1000` milliseconds duration.
-* `int` - enable container animation with `linear` curve and specified number of milliseconds. 
-* `animation.Animation(duration: int, curve: str)` - enable container animation with specified duration and transition curve.
-
-For example:
-
-<img src="/img/docs/controls/container/animate-container.gif" className="screenshot-20" />
-
-```python
-import flet as ft
-
-def main(page: ft.Page):
-
-    c = ft.Container(
-        width=200,
-        height=200,
-        bgcolor="red",
-        animate=ft.animation.Animation(1000, "bounceOut"),
-    )
-
-    def animate_container(e):
-        c.width = 100 if c.width == 200 else 200
-        c.height = 100 if c.height == 200 else 200
-        c.bgcolor = "blue" if c.bgcolor == "red" else "red"
-        c.update()
-
-    page.add(c, ft.ElevatedButton("Animate container", on_click=animate_container))
-
-ft.app(target=main)
-```
+Sets an image encoded as Base-64 string as a container background. See [`Image.src_base64`](image#src_base64) for more details.
 
 ### `ink`
 
 `True` to produce ink ripples effect when user clicks the container. Default is `False`.
 
-### `clip_behavior`
+### `margin`
 
-The content will be clipped (or not) according to this option.
+Empty space to surround the decoration and child control.
 
-Property value is `ClipBehavior` enum with supported values:
+Margin is an instance of `margin.Margin` class with properties set margins for all sides of the rectangle: `left`, `top`, `right`, `bottom`. An instance of `margin.Margin` can be created via constructor with values for specific sides or created with helper methods:
 
-* `NONE` (default)
-* `ANTI_ALIAS`
-* `ANTI_ALIAS_WITH_SAVE_LAYER`
-* `HARD_EDGE`
+* `margin.all(value)`
+* `margin.symmetric(vertical, horizontal)`
+* `margin.only(left, top, right, bottom)`
+
+For example:
+
+```python
+
+container_1.margin = margin.all(10)
+container_2.margin = 20 # same as margin.all(20)
+container_3.margin = margin.symmetric(vertical=10)
+container_3.margin = margin.only(left=10)
+```
+<img src="/img/docs/controls/container/container-margin-diagram.png" className="screenshot-50" />
+
+### `padding`
+
+Empty space to inscribe inside a container decoration (background, border). The child control is placed inside this padding.
+
+Padding is an instance of `padding.Padding` class with properties set padding for all sides of the rectangle: `left`, `top`, `right`, `bottom`. An instance of `padding.Padding` can be created via constructor with values for specific sides or created with helper methods:
+
+* `padding.all(value: float)`
+* `padding.symmetric(vertical, horizontal)`
+* `padding.only(left, top, right, bottom)`
+
+For example:
+
+```python
+
+container_1.padding = ft.padding.all(10)
+container_2.padding = 20 # same as ft.padding.all(20)
+container_3.padding = ft.padding.symmetric(horizontal=10)
+container_4.padding=padding.only(left=10)
+```
+
+<img src="/img/docs/controls/container/container-padding-diagram.png" className="screenshot-50" />
+
+### `shape`
+
+Sets the shape of the container. The value is `BoxShape` enum:
+
+* `RECTANGLE` (default)
+* `CIRCLE`
 
 ## Events
 
@@ -463,10 +463,6 @@ def main(page: ft.Page):
 ft.app(target=main)
 ```
 
-### `on_long_press`
-
-Fires when the container is long-pressed.
-
 ### `on_hover`
 
 Fires when a mouse pointer enters or exists the container area. `data` property of event object contains `true` (string) when cursor enters and `false` when it exits.
@@ -487,3 +483,7 @@ def main(page: ft.Page):
 
 ft.app(target=main)
 ```
+
+### `on_long_press`
+
+Fires when the container is long-pressed.

--- a/docs/controls/divider.md
+++ b/docs/controls/divider.md
@@ -58,6 +58,10 @@ ft.app(target=main)
 
 ## Properties
 
+### `color`
+
+The color to use when painting the line.
+
 ### `height`
 
 The divider's height extent. The divider itself is always drawn as a horizontal line that is centered within the height specified by this value. If this is null, then this defaults to `16.0`.
@@ -65,7 +69,3 @@ The divider's height extent. The divider itself is always drawn as a horizontal 
 ### `thickness`
 
 The thickness of the line drawn within the divider. A divider with a thickness of `0.0` is always drawn as a line with a height of exactly one device pixel. If this is null, then this defaults to `0.0`.
-
-### `color`
-
-The color to use when painting the line.

--- a/docs/controls/draggable.md
+++ b/docs/controls/draggable.md
@@ -108,13 +108,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `group`
-
-A group this draggable belongs to. For [DragTarget](dragtarget) to accept incoming drag both `Draggable` and `DragTarget` must be in the same `group`.
-
 ### `content`
 
 `Draggable` control displays [`content`](#content) when zero drags are under way. If [`content_when_dragging`](#contentwhendragging) is non-null, this control instead displays `content_when_dragging` when one or more drags are underway. Otherwise, this control always displays `content`.
+
+### `content_feedback`
+
+The `Control` to show under the pointer when a drag is under way.
 
 ### `content_when_dragging`
 
@@ -122,6 +122,6 @@ The `Control` to display instead of `content` when one or more drags are under w
 
 If this is `None`, then this widget will always display `content` (and so the drag source representation will not change while a drag is under way).
 
-### `content_feedback`
+### `group`
 
-The `Control` to show under the pointer when a drag is under way.
+A group this draggable belongs to. For [DragTarget](dragtarget) to accept incoming drag both `Draggable` and `DragTarget` must be in the same `group`.

--- a/docs/controls/dragtarget.md
+++ b/docs/controls/dragtarget.md
@@ -106,19 +106,15 @@ ft.app(target=main)
 
 ## Properties
 
-### `group`
-
-A group this drag target belongs to. For [DragTarget](dragtarget) to accept incoming drag both `Draggable` and `DragTarget` must be in the same `group`.
-
 ### `content`
 
 The `Control` that is a visual representation of the drag target.
 
+### `group`
+
+A group this drag target belongs to. For [DragTarget](dragtarget) to accept incoming drag both `Draggable` and `DragTarget` must be in the same `group`.
+
 ## Events
-
-### `on_will_accept`
-
-Fires when draggable is dragged on top of a drag target. `data` field of event details contains `true` (String) if both `Draggable` and `DragTarget` has the same `group`; otherwise `false` (String).
 
 ### `on_accept`
 
@@ -133,3 +129,7 @@ Use `page.get_control(e.src_id)` to retrieve Control reference by its ID.
 ### `on_leave`
 
 Fires when a mouse pointer during ongoing drag event leaves the target.
+
+### `on_will_accept`
+
+Fires when draggable is dragged on top of a drag target. `data` field of event details contains `true` (String) if both `Draggable` and `DragTarget` has the same `group`; otherwise `false` (String).

--- a/docs/controls/dropdown.md
+++ b/docs/controls/dropdown.md
@@ -149,17 +149,109 @@ ft.app(target=main)
 
 ## `Dropdown` properties
 
-### `options`
+### `alignment`
 
-A list of `Option` controls representing items in the dropdown.
+Defines how the hint or the selected item is positioned within the dropdown.
 
-### `value`
-
-`key` value of the selected option.
+See [`Container.alignment`](/docs/controls/container#alignment) property for possible values.
 
 ### `autofocus`
 
 True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `bgcolor`
+
+Dropdown background color.
+
+### `border`
+
+Border around input - `InputBorder` enum with one of the values: `OUTLINE` (default), `UNDERLINE`, `NONE`.
+
+### `border_color`
+
+Border color. Could be `transparent` to hide the border.
+
+### `border_radius`
+
+See [`Container.border_radius`] property docs for more information about border radius.
+
+### `border_width`
+
+The width of the border in virtual pixels. Default is 1. Set to 0 to completely remove border.
+
+### `color`
+
+Text color.
+
+### `content_padding`
+
+The padding for the input decoration's container.
+
+### `counter_style`
+
+The style to use for `counter_text`.
+
+### `counter_text`
+
+Optional text to place below the line as a character count.
+
+If null or an empty string and counter isn't specified, then nothing will appear in the counter's location.
+
+### `error_style`
+
+The style to use for `error_text`.
+
+### `error_text`
+
+Text that appears below the input border.
+
+If non-null, the border's color animates to red and the `helper_text` is not shown.
+
+### `filled`
+
+If `True` the decoration's container is filled with theme fillColor.
+
+### `focused_bgcolor`
+
+Background color of dropdown in focused state.
+
+### `focused_border_color`
+
+Border color in focused state.
+
+### `focused_border_width`
+
+Border width in focused state.
+
+### `focused_color`
+
+Text color when Dropdown is focused.
+
+### `helper_style`
+
+The style to use for `helper_text`.
+
+### `helper_text`
+
+Text that provides context about the input's value, such as how the value will be used.
+
+If non-null, the text is displayed below the input decorator, in the same location as `error_text`. If a non-null `error_text` value is specified then the helper text is not shown.
+
+### `hint_style`
+
+The style to use for `hint_text`.
+
+### `hint_text`
+
+Text that suggests what sort of input the field accepts.
+
+Displayed on top of the input when it's empty and either (a) `label` is null or (b) the input has the focus.
+
+### `icon`
+
+The name of the icon to show before the input field and outside of the decoration's container.
+
+See [`Container.padding`](container#padding) for more information about padding and possible values.
 
 ### `label`
 
@@ -171,107 +263,9 @@ When the input field is empty and unfocused, the label is displayed on top of th
 
 The style to use for `label`.
 
-### `icon`
+### `options`
 
-The name of the icon to show before the input field and outside of the decoration's container.
-
-### `border`
-
-Border around input - `InputBorder` enum with one of the values: `OUTLINE` (default), `UNDERLINE`, `NONE`.
-
-### `content_padding`
-
-The padding for the input decoration's container.
-
-See [`Container.padding`](container#padding) for more information about padding and possible values.
-
-### `filled`
-
-If `True` the decoration's container is filled with theme fillColor.
-
-### `text_size`
-
-Text size in virtual pixels.
-
-### `text_style`
-
-The text style to use for text in the dropdown button and the dropdown menu that appears when you tap the button.
-
-### `color`
-
-Text color.
-
-### `bgcolor`
-
-Dropdown background color.
-
-### `border_radius`
-
-See [`Container.border_radius`] property docs for more information about border radius.
-
-### `border_width`
-
-The width of the border in virtual pixels. Default is 1. Set to 0 to commpletely remove border.
-
-### `border_color`
-
-Border color. Could be `transparent` to hide the border.
-
-### `focused_color`
-
-Text color when Dropdown is focused.
-
-### `focused_bgcolor`
-
-Background color of dropdown in focused state.
-
-### `focused_border_width`
-
-Border width in focused state.
-
-### `focused_border_color`
-
-Border color in focused state.
-
-### `hint_text`
-
-Text that suggests what sort of input the field accepts.
-
-Displayed on top of the input when the it's empty and either (a) `label` is null or (b) the input has the focus.
-
-### `hint_style`
-
-The style to use for `hint_text`.
-
-### `helper_text`
-
-Text that provides context about the input's value, such as how the value will be used.
-
-If non-null, the text is displayed below the input decorator, in the same location as `error_text`. If a non-null `error_text` value is specified then the helper text is not shown.
-
-### `helper_style`
-
-The style to use for `helper_text`.
-
-### `counter_text`
-
-Optional text to place below the line as a character count.
-
-If null or an empty string and counter isn't specified, then nothing will appear in the counter's location.
-
-### `counter_style`
-
-The style to use for `counter_text`.
-
-### `error_text`
-
-Text that appears below the input border.
-
-If non-null, the border's color animates to red and the `helper_text` is not shown.
-
-### `error_style`
-
-The style to use for `error_text`.
+A list of `Option` controls representing items in the dropdown.
 
 ### `prefix`
 
@@ -287,13 +281,13 @@ The `prefix` appears after the `prefix_icon`, if both are specified.
 
 An icon that appears before the `prefix` or `prefix_text` and before the editable part of the text field, within the decoration's container.
 
-### `prefix_text`
-
-Optional text `prefix` to place on the line before the input.
-
 ### `prefix_style`
 
 The style to use for `prefix_text`.
+
+### `prefix_text`
+
+Optional text `prefix` to place on the line before the input.
 
 ### `suffix`
 
@@ -309,19 +303,25 @@ The `suffix` appears before the `suffix_icon`, if both are specified.
 
 An icon that appears after the editable part of the text field and after the `suffix` or `suffix_text`, within the decoration's container.
 
-### `suffix_text`
-
-Optional text `suffix` to place on the line after the input.
-
 ### `suffix_style`
 
 The style to use for `suffix_text`.
 
-### `alignment`
+### `suffix_text`
 
-Defines how the hint or the selected item is positioned within the dropdown.
+Optional text `suffix` to place on the line after the input.
 
-See [`Container.alignment`](/docs/controls/container#alignment) property for possible values.
+### `text_size`
+
+Text size in virtual pixels.
+
+### `text_style`
+
+The text style to use for text in the dropdown button and the dropdown menu that appears when you tap the button.
+
+### `value`
+
+`key` value of the selected option.
 
 ## `Dropdown` methods
 
@@ -331,6 +331,10 @@ Moves focus to a Dropdown.
 
 ## `Dropdown` events
 
+### `on_blur`
+
+Fires when the control has lost focus.
+
 ### `on_change`
 
 Fires when the selected item of the Dropdown has changed.
@@ -338,10 +342,6 @@ Fires when the selected item of the Dropdown has changed.
 ### `on_focus`
 
 Fires when the control has received focus.
-
-### `on_blur`
-
-Fires when the control has lost focus.
 
 ## `Option` properties
 

--- a/docs/controls/elevatedbutton.md
+++ b/docs/controls/elevatedbutton.md
@@ -140,17 +140,21 @@ ft.app(target=main)
 
 ## Properties
 
-### `text`
+### `autofocus`
 
-The text displayed on a button.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `bgcolor`
+
+Button's background color.
 
 ### `color`
 
 Button's text color.
 
-### `bgcolor`
+### `content`
 
-Button's background color.
+A Control representing custom button content.
 
 ### `elevation`
 
@@ -309,27 +313,19 @@ def main(page: ft.Page):
 ft.app(target=main)
 ```
 
+### `text`
+
+The text displayed on a button.
+
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
-### `content`
-
-A Control representing custom button content.
 
 ## Events
 
 ### `on_click`
 
 Fires when a user clicks the button.
-
-### `on_long_press`
-
-Fires when the button is long-pressed.
 
 ### `on_hover`
 
@@ -351,3 +347,7 @@ def main(page: ft.Page):
 
 ft.app(target=main)
 ```
+
+### `on_long_press`
+
+Fires when the button is long-pressed.

--- a/docs/controls/filepicker.md
+++ b/docs/controls/filepicker.md
@@ -65,19 +65,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `file_type`
-
-Allow to pick files of specific group.
-
-Property value is `FilePickerFileType` enum with the following values:
-
-* `ANY` (default) - any file
-* `IMAGE`
-* `VIDEO`
-* `MEDIA` - `VIDEO` and `IMAGE`
-* `AUDIO`
-* `CUSTOM` - only files with extensions from `allowed_extensions` list
-
 ### `allowed_extensions`
 
 Allow picking files with specified extensions only.
@@ -92,13 +79,26 @@ Allow selecting multiple files.
 
 Can be optionally set on desktop platforms to set the modal window title. It will be ignored on other platforms.
 
-### `initial_directory`
-
-Can be optionally set to an absolute path to specify where the dialog should open. Only supported on Linux, macOS, and Windows.
-
 ### `file_name`
 
 Works for "Save file" dialog only. Can be set to a non-empty string to provide a default file name.
+
+### `file_type`
+
+Allow to pick files of specific group.
+
+Property value is `FilePickerFileType` enum with the following values:
+
+* `ANY` (default) - any file
+* `IMAGE`
+* `VIDEO`
+* `MEDIA` - `VIDEO` and `IMAGE`
+* `AUDIO`
+* `CUSTOM` - only files with extensions from `allowed_extensions` list
+
+### `initial_directory`
+
+Can be optionally set to an absolute path to specify where the dialog should open. Only supported on Linux, macOS, and Windows.
 
 ### `result`
 
@@ -116,6 +116,15 @@ The value of this property is an instance of `FilePickerResultEvent` class:
 * `size` - file size in bytes.
 
 ## Methods
+
+### `get_directory_path()`
+
+Selects a directory and returns its absolute path.
+
+You could either set the following file picker properties or provide their values in the method call:
+
+* `dialog_title`
+* `initial_directory`
 
 ### `pick_files()`
 
@@ -144,15 +153,6 @@ You could either set the following file picker properties or provide their value
 * `initial_directory`
 * `file_type`
 * `allowed_extensions`
-
-### `get_directory_path()`
-
-Selects a directory and returns its absolute path.
-
-You could either set the following file picker properties or provide their values in the method call:
-
-* `dialog_title`
-* `initial_directory`
 
 ### `upload()`
 

--- a/docs/controls/filledbutton.md
+++ b/docs/controls/filledbutton.md
@@ -38,9 +38,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `text`
+### `autofocus`
 
-The text displayed on a button.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `content`
+
+A Control representing custom button content.
 
 ### `icon`
 
@@ -54,17 +58,13 @@ Icon color.
 
 See [ElevatedButton.style](elevatedbutton#style) for more information about this property.
 
+### `text`
+
+The text displayed on a button.
+
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
-### `content`
-
-A Control representing custom button content.
 
 ## Events
 
@@ -72,10 +72,10 @@ A Control representing custom button content.
 
 Fires when a user clicks the button.
 
-### `on_long_press`
-
-Fires when the button is long-pressed.
-
 ### `on_hover`
 
 Fires when a mouse pointer enters or exists the button response area. `data` property of event object contains `true` (string) when cursor enters and `false` when it exits.
+
+### `on_long_press`
+
+Fires when the button is long-pressed.

--- a/docs/controls/filledtonalbutton.md
+++ b/docs/controls/filledtonalbutton.md
@@ -36,9 +36,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `text`
+### `autofocus`
 
-The text displayed on a button.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `content`
+
+A Control representing custom button content.
 
 ### `icon`
 
@@ -52,17 +56,13 @@ Icon color.
 
 See [ElevatedButton.style](elevatedbutton#style) for more information about this property.
 
+### `text`
+
+The text displayed on a button.
+
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
-### `content`
-
-A Control representing custom button content.
 
 ## Events
 
@@ -70,10 +70,10 @@ A Control representing custom button content.
 
 Fires when a user clicks the button.
 
-### `on_long_press`
-
-Fires when the button is long-pressed.
-
 ### `on_hover`
 
 Fires when a mouse pointer enters or exists the button response area. `data` property of event object contains `true` (string) when cursor enters and `false` when it exits.
+
+### `on_long_press`
+
+Fires when the button is long-pressed.

--- a/docs/controls/floatingactionbutton.md
+++ b/docs/controls/floatingactionbutton.md
@@ -62,29 +62,21 @@ ft.app(target=main)
 
 ## Properties
 
-### `content`
+### `autofocus`
 
-A Control representing custom button content.
-
-### `text`
-
-The text displayed on a button.
-
-### `icon`
-
-Icon shown in the button.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
 
 ### `bgcolor`
 
 Button background color.
 
-### `tooltip`
+### `content`
 
-The text displayed when hovering the mouse over the button.
+A Control representing custom button content.
 
-### `autofocus`
+### `icon`
 
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+Icon shown in the button.
 
 ### `mini`
 
@@ -129,6 +121,14 @@ ft.app(target=main)
 ```
 
 <img src="/img/docs/controls/floatingactionbutton/fab-with-custom-shape.png" className="screenshot-20" />
+
+### `text`
+
+The text displayed on a button.
+
+### `tooltip`
+
+The text displayed when hovering the mouse over the button.
 
 ## Events
 

--- a/docs/controls/gesturedetector.md
+++ b/docs/controls/gesturedetector.md
@@ -121,83 +121,9 @@ Throttling in milliseconds for `on_hover` event.
 
 ## Events
 
-### `on_tap`
+### `multi_tap_touches`
 
-A tap with a primary button has occurred.
-
-### `on_tap_down`
-
-A pointer that might cause a tap with a primary button has contacted the screen at a particular location.
-
-Event handler argument is an instance of `TapEvent` class with the following properties:
-
-* `local_x` - x component of the local position at which the pointer contacted the screen.
-* `local_y` - y component of the local position at which the pointer contacted the screen.
-* `global_x` - x component of the global position at which the pointer contacted the screen.
-* `global_y` - y component of the global position at which the pointer contacted the screen.
-* `kind` - The kind of the device that initiated the event.
-
-### `on_tap_up`
-
-A pointer that will trigger a tap with a primary button has stopped contacting the screen at a particular location.
-
-Event handler argument is an instance of `TapEvent` class.
-
-### `on_secondary_tap`
-
-A tap with a secondary button has occurred.
-
-### `on_secondary_tap_down`
-
-A pointer that might cause a tap with a secondary button has contacted the screen at a particular location.
-
-Event handler argument is an instance of `TapEvent` class.
-
-### `on_secondary_tap_up`
-
-A pointer that will trigger a tap with a secondary button has stopped contacting the screen at a particular location.
-
-Event handler argument is an instance of `TapEvent` class.
-
-### `on_long_press_start`
-
-Called when a long press gesture with a primary button has been recognized.
-
-Triggered when a pointer has remained in contact with the screen at the same location for a long period of time.
-
-Event handler argument is an instance of `LongPressStartEvent` class with the following properties:
-
-* `local_x` - x component of the local position at which the pointer contacted the screen.
-* `local_y` - y component of the local position at which the pointer contacted the screen.
-* `global_x` - x component of the global position at which the pointer contacted the screen.
-* `global_y` - y component of the global position at which the pointer contacted the screen.
-
-### `on_long_press_end`
-
-A pointer that has triggered a long-press with a primary button has stopped contacting the screen.
-
-Event handler argument is an instance of `LongPressEndEvent` class with the following properties:
-
-* `local_x` - x component of the local position at which the pointer contacted the screen.
-* `local_y` - y component of the local position at which the pointer contacted the screen.
-* `global_x` - x component of the global position at which the pointer contacted the screen.
-* `global_y` - y component of the global position at which the pointer contacted the screen.
-* `velocity_x` - x component of the pointer's velocity when it stopped contacting the screen.
-* `velocity_y` - y component of the pointer's velocity when it stopped contacting the screen.
-
-### `on_secondary_long_press_start`
-
-Called when a long press gesture with a secondary button has been recognized.
-
-Triggered when a pointer has remained in contact with the screen at the same location for a long period of time.
-
-Event handler argument is an instance of `LongPressStartEvent` class.
-
-### `on_secondary_long_press_end`
-
-A pointer that has triggered a long-press with a secondary button has stopped contacting the screen.
-
-Event handler argument is an instance of `LongPressEndEvent` class.
+The minimum number of pointers to trigger `on_multi_tap` event.
 
 ### `on_double_tap`
 
@@ -210,6 +136,28 @@ A pointer that might cause a double tap has contacted the screen at a particular
 Triggered immediately after the down event of the second tap.
 
 Event handler argument is an instance of `TapEvent` class.
+
+### `on_enter`
+
+Triggered when a mouse pointer has entered this control.
+
+Event handler argument is an instance of `HoverEvent` class.
+
+### `on_exit`
+
+Triggered when a mouse pointer has exited this control.
+
+Event handler argument is an instance of `HoverEvent` class.
+
+### `on_horizontal_drag_end`
+
+A pointer that was previously in contact with the screen with a primary button and moving horizontally is no longer in contact with the screen and was moving at a specific velocity when it stopped contacting the screen.
+
+Event handler argument is an instance of `DragEndEvent` class with the following properties:
+
+* `primary_velocity` - the velocity the pointer was moving along the primary axis when it stopped contacting the screen, in logical pixels per second.
+* `velocity_x` - x component of the pointer's velocity when it stopped contacting the screen.
+* `velocity_y` - y component of the pointer's velocity when it stopped contacting the screen.
 
 ### `on_horizontal_drag_start`
 
@@ -238,31 +186,49 @@ Event handler argument is an instance of `DragUpdateEvent` class with the follow
 * `primary_delta` - the amount the pointer has moved along the primary axis in the coordinate space of the event receiver since the previous update.
 * `timestamp` - recorded timestamp of the source pointer event that triggered the drag event.
 
-### `on_horizontal_drag_end`
+### `on_hover`
 
-A pointer that was previously in contact with the screen with a primary button and moving horizontally is no longer in contact with the screen and was moving at a specific velocity when it stopped contacting the screen.
+Triggered when a mouse pointer has entered this control.
 
-Event handler argument is an instance of `DragEndEvent` class with the following properties:
+Event handler argument is an instance of `HoverEvent` class with the following properties:
 
-* `primary_velocity` - the velocity the pointer was moving along the primary axis when it stopped contacting the screen, in logical pixels per second.
+* `local_x` - x component of the local position of the pointer.
+* `local_y` - y component of the local position of the pointer.
+* `global_x` - x component of the global position of the pointer.
+* `global_y` - y component of the global position of the pointer.
+* `delta_x` - x component of the distance in logical pixels that the pointer moved since the last hover event.
+* `delta_x` - y component of the distance in logical pixels that the pointer moved since the last hover event.
+* `timestamp` - event's timestamp.
+
+### `on_long_press_end`
+
+A pointer that has triggered a long-press with a primary button has stopped contacting the screen.
+
+Event handler argument is an instance of `LongPressEndEvent` class with the following properties:
+
+* `local_x` - x component of the local position at which the pointer contacted the screen.
+* `local_y` - y component of the local position at which the pointer contacted the screen.
+* `global_x` - x component of the global position at which the pointer contacted the screen.
+* `global_y` - y component of the global position at which the pointer contacted the screen.
 * `velocity_x` - x component of the pointer's velocity when it stopped contacting the screen.
 * `velocity_y` - y component of the pointer's velocity when it stopped contacting the screen.
 
-### `on_vertical_drag_start`
+### `on_long_press_start`
 
-A pointer has contacted the screen with a primary button and has begun to move vertically.
+Called when a long press gesture with a primary button has been recognized.
 
-Event handler argument is an instance of `DragStartEvent` class.
+Triggered when a pointer has remained in contact with the screen at the same location for a long period of time.
 
-### `on_vertical_drag_update`
+Event handler argument is an instance of `LongPressStartEvent` class with the following properties:
 
-A pointer that is in contact with the screen with a primary button and moving vertically has moved in the vertical direction.
+* `local_x` - x component of the local position at which the pointer contacted the screen.
+* `local_y` - y component of the local position at which the pointer contacted the screen.
+* `global_x` - x component of the global position at which the pointer contacted the screen.
+* `global_y` - y component of the global position at which the pointer contacted the screen.
 
-Event handler argument is an instance of `DragUpdateEvent` class.
+### `on_pan_end`
 
-### `on_vertical_drag_end`
-
-A pointer that was previously in contact with the screen with a primary button and moving vertically is no longer in contact with the screen and was moving at a specific velocity when it stopped contacting the screen.
+A pointer that was previously in contact with the screen with a primary button and moving is no longer in contact with the screen and was moving at a specific velocity when it stopped contacting the screen.
 
 Event handler argument is an instance of `DragEndEvent` class.
 
@@ -278,11 +244,13 @@ A pointer that is in contact with the screen with a primary button and moving ha
 
 Event handler argument is an instance of `DragUpdateEvent` class.
 
-### `on_pan_end`
+### `on_scale_end`
 
-A pointer that was previously in contact with the screen with a primary button and moving is no longer in contact with the screen and was moving at a specific velocity when it stopped contacting the screen.
+Event handler argument is an instance of `ScaleEndEvent` class with the following properties:
 
-Event handler argument is an instance of `DragEndEvent` class.
+* `pointer_count` - the number of pointers being tracked by the gesture recognizer.
+* `velocity_x` - x component of the velocity of the last pointer to be lifted off of the screen.
+* `velocity_y` - y component of the velocity of the last pointer to be lifted off of the screen.
 
 ### `on_scale_start`
 
@@ -311,39 +279,79 @@ Event handler argument is an instance of `ScaleUpdateEvent` class with the follo
 * `vertical_scale` - the scale implied by the average distance along the vertical axis between the pointers in contact with the screen.
 * `scale` - the scale implied by the average distance between the pointers in contact with the screen.
 
-### `on_scale_end`
+### `on_secondary_long_press_end`
 
-Event handler argument is an instance of `ScaleEndEvent` class with the following properties:
+A pointer that has triggered a long-press with a secondary button has stopped contacting the screen.
 
-* `pointer_count` - the number of pointers being tracked by the gesture recognizer.
-* `velocity_x` - x component of the velocity of the last pointer to be lifted off of the screen.
-* `velocity_y` - y component of the velocity of the last pointer to be lifted off of the screen.
+Event handler argument is an instance of `LongPressEndEvent` class.
 
-### `on_hover`
+### `on_secondary_long_press_start`
 
-Triggered when a mouse pointer has entered this control.
+Called when a long press gesture with a secondary button has been recognized.
 
-Event handler argument is an instance of `HoverEvent` class with the following properties:
+Triggered when a pointer has remained in contact with the screen at the same location for a long period of time.
 
-* `local_x` - x component of the local position of the pointer.
-* `local_y` - y component of the local position of the pointer.
-* `global_x` - x component of the global position of the pointer.
-* `global_y` - y component of the global position of the pointer.
-* `delta_x` - x component of the distance in logical pixels that the pointer moved since the last hover event.
-* `delta_x` - y component of the distance in logical pixels that the pointer moved since the last hover event.
-* `timestamp` - event's timestamp.
+Event handler argument is an instance of `LongPressStartEvent` class.
 
-### `on_enter`
+### `on_secondary_tap`
 
-Triggered when a mouse pointer has entered this control.
+A tap with a secondary button has occurred.
 
-Event handler argument is an instance of `HoverEvent` class.
+### `on_secondary_tap_down`
 
-### `on_exit`
+A pointer that might cause a tap with a secondary button has contacted the screen at a particular location.
 
-Triggered when a mouse pointer has exited this control.
+Event handler argument is an instance of `TapEvent` class.
 
-Event handler argument is an instance of `HoverEvent` class.
+### `on_secondary_tap_up`
+
+A pointer that will trigger a tap with a secondary button has stopped contacting the screen at a particular location.
+
+Event handler argument is an instance of `TapEvent` class.
+
+### `on_tap`
+
+A tap with a primary button has occurred.
+
+### `on_tap_down`
+
+A pointer that might cause a tap with a primary button has contacted the screen at a particular location.
+
+Event handler argument is an instance of `TapEvent` class with the following properties:
+
+* `local_x` - x component of the local position at which the pointer contacted the screen.
+* `local_y` - y component of the local position at which the pointer contacted the screen.
+* `global_x` - x component of the global position at which the pointer contacted the screen.
+* `global_y` - y component of the global position at which the pointer contacted the screen.
+* `kind` - The kind of the device that initiated the event.
+
+### `on_tap_up`
+
+A pointer that will trigger a tap with a primary button has stopped contacting the screen at a particular location.
+
+Event handler argument is an instance of `TapEvent` class.
+
+### `on_vertical_drag_end`
+
+A pointer that was previously in contact with the screen with a primary button and moving vertically is no longer in contact with the screen and was moving at a specific velocity when it stopped contacting the screen.
+
+Event handler argument is an instance of `DragEndEvent` class.
+
+### `on_vertical_drag_start`
+
+A pointer has contacted the screen with a primary button and has begun to move vertically.
+
+Event handler argument is an instance of `DragStartEvent` class.
+
+### `on_vertical_drag_update`
+
+A pointer that is in contact with the screen with a primary button and moving vertically has moved in the vertical direction.
+
+Event handler argument is an instance of `DragUpdateEvent` class.
+
+### `on_multi_long_press`
+
+Called when a long press gesture with multiple pointers has been recognized.
 
 ### `on_multi_tap`
 
@@ -352,14 +360,6 @@ Triggered when multiple pointers contacted the screen.
 Event handler argument is an instance of `MultiTapEvent` class with the following properties:
 
 * `correct_touches` - `True` a `multi_tap_touches` number of pointers touched the screen; otherwise `False`.
-
-### `multi_tap_touches`
-
-The minimum number of pointers to trigger `on_multi_tap` event.
-
-### `on_multi_long_press`
-
-Called when a long press gesture with multiple pointers has been recognized.
 
 ### `on_scroll`
 

--- a/docs/controls/gridview.md
+++ b/docs/controls/gridview.md
@@ -60,6 +60,10 @@ ft.app(target=main, view=ft.WEB_BROWSER)
 
 ## Properties
 
+### `child_aspect_ratio`
+
+The ratio of the cross-axis to the main-axis extent of each child.
+
 ### `controls`
 
 A list of `Control`s to display inside GridView.
@@ -68,26 +72,22 @@ A list of `Control`s to display inside GridView.
 
 `True` to layout GridView items horizontally.
 
-### `runs_count`
-
-The number of children in the cross axis.
-
 ### `max_extent`
-
-### `spacing`
-
-The number of logical pixels between each child along the main axis.
-
-### `run_spacing`
-
-The number of logical pixels between each child along the cross axis.
-
-### `child_aspect_ratio`
-
-The ratio of the cross-axis to the main-axis extent of each child.
 
 ### `padding`
 
 The amount of space by which to inset the children.
 
 See [`Container.padding`](container#padding) property for more information and possible values.
+
+### `run_spacing`
+
+The number of logical pixels between each child along the cross axis.
+
+### `runs_count`
+
+The number of children in the cross axis.
+
+### `spacing`
+
+The number of logical pixels between each child along the main axis.

--- a/docs/controls/hapticfeedback.md
+++ b/docs/controls/hapticfeedback.md
@@ -35,13 +35,13 @@ ft.app(target=main)
 
 Provides a haptic feedback corresponding a collision impact with a heavy mass.
 
-### `medium_impact()`
-
-Provides a haptic feedback corresponding a collision impact with a medium mass.
-
 ### `light_impact()`
 
 Provides a haptic feedback corresponding a collision impact with a light mass.
+
+### `medium_impact()`
+
+Provides a haptic feedback corresponding a collision impact with a medium mass.
 
 ### `vibrate()`
 

--- a/docs/controls/icon.md
+++ b/docs/controls/icon.md
@@ -42,13 +42,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `name`
-
-The name of the icon. You can search through the list of all available icons using open-source [Icons browser](https://flet-icons-browser.fly.dev/#/) app [written in Flet](https://github.com/flet-dev/examples/blob/main/python/apps/icons-browser/main.py).
-
 ### `color`
 
 Icon color.
+
+### `name`
+
+The name of the icon. You can search through the list of all available icons using open-source [Icons browser](https://flet-icons-browser.fly.dev/#/) app [written in Flet](https://github.com/flet-dev/examples/blob/main/python/apps/icons-browser/main.py).
 
 ### `size`
 

--- a/docs/controls/iconbutton.md
+++ b/docs/controls/iconbutton.md
@@ -84,6 +84,14 @@ ft.app(target=main)
 
 ## Properties
 
+### `autofocus`
+
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `content`
+
+A Control representing custom button content.
+
 ### `icon`
 
 Icon shown in the button.
@@ -141,14 +149,6 @@ See [ElevatedButton.style](elevatedbutton#style) for more information about this
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
-### `content`
-
-A Control representing custom button content.
 
 ## Events
 

--- a/docs/controls/image.md
+++ b/docs/controls/image.md
@@ -55,6 +55,42 @@ ft.app(target=main)
 
 ## Properties
 
+### `border_radius`
+
+Clip image to have rounded corners. See [`Container.border_radius`](container#border_radius) for more information and examples.
+
+### `color`
+
+If set, this color is blended with each image pixel using `color_blend_mode`.
+
+### `color_blend_mode`
+
+Used to combine `color` with the image.
+
+The default is `BlendMode.COLOR`. In terms of the blend mode, color is the source and this image is the destination.
+
+See [`ShaderMask.blend_mode`](shadermask#blend_mode) for possible blend mode values.
+
+### `fit`
+
+How to inscribe the image into the space allocated during layout.
+
+Property value is `ImageFit` enum with supported values: `NONE` (default), `CONTAIN`, `COVER`, `FILL`, `FIT_HEIGHT`, `FIT_WIDTH`, `SCALE_DOWN`.
+
+### `gapless_playback`
+
+Whether to continue showing the old image (`True`), or briefly show nothing (`False`), when the image provider changes. The default value is `False`.
+
+### `height`
+
+If set, require the image to have this height.
+
+If not set, the image will pick a size that best preserves its intrinsic aspect ratio.
+
+:::note
+It is strongly recommended that either both the width and the height be specified, or that the Image be placed in a context that sets tight layout constraints, so that the image does not change size as it loads. Consider using `fit` to adapt the image's rendering to fit the given width and height if the exact image dimensions are not known in advance.
+:::
+
 ### `src`
 
 Image URL. This could be an external URL, e.g. `https://picsum.photos/200/200` or internal URL to reference app assets, e.g. `/my-image.png`.
@@ -106,6 +142,20 @@ On Windows you can use PowerShell to encode string into Base64 format:
 [convert]::ToBase64String((Get-Content -path "your_file_path" -Encoding byte))
 ```
 
+### `repeat`
+
+How to paint any portions of the layout bounds not covered by the image.
+
+Property value is `ImageRepeat` enum with supported values: `NO_REPEAT` (default), `REPEAT`, `REPEAT_X`, `REPEAT_Y`.
+
+### `semantics_label`
+
+A semantics label for this image.
+
+### `tooltip`
+
+The text displayed when hovering a mouse over the Image.
+
 ### `width`
 
 If set, require the image to have this width.
@@ -115,53 +165,3 @@ If not set, the image will pick a size that best preserves its intrinsic aspect 
 :::note
 It is strongly recommended that either both the width and the height be specified, or that the Image be placed in a context that sets tight layout constraints, so that the image does not change size as it loads. Consider using `fit` to adapt the image's rendering to fit the given width and height if the exact image dimensions are not known in advance.
 :::
-
-### `height`
-
-If set, require the image to have this height.
-
-If not set, the image will pick a size that best preserves its intrinsic aspect ratio.
-
-:::note
-It is strongly recommended that either both the width and the height be specified, or that the Image be placed in a context that sets tight layout constraints, so that the image does not change size as it loads. Consider using `fit` to adapt the image's rendering to fit the given width and height if the exact image dimensions are not known in advance.
-:::
-
-### `repeat`
-
-How to paint any portions of the layout bounds not covered by the image.
-
-Property value is `ImageRepeat` enum with supported values: `NO_REPEAT` (default), `REPEAT`, `REPEAT_X`, `REPEAT_Y`.
-
-### `fit`
-
-How to inscribe the image into the space allocated during layout.
-
-Property value is `ImageFit` enum with supported values: `NONE` (default), `CONTAIN`, `COVER`, `FILL`, `FIT_HEIGHT`, `FIT_WIDTH`, `SCALE_DOWN`.
-
-### `border_radius`
-
-Clip image to have rounded corners. See [`Container.border_radius`](container#border_radius) for more information and examples.
-
-### `color`
-
-If set, this color is blended with each image pixel using `color_blend_mode`.
-
-### `color_blend_mode`
-
-Used to combine `color` with the image.
-
-The default is `BlendMode.COLOR`. In terms of the blend mode, color is the source and this image is the destination.
-
-See [`ShaderMask.blend_mode`](shadermask#blend_mode) for possible blend mode values.
-
-### `gapless_playback`
-
-Whether to continue showing the old image (`True`), or briefly show nothing (`False`), when the image provider changes. The default value is `False`.
-
-### `tooltip`
-
-The text displayed when hovering a mouse over the Image.
-
-### `semantics_label`
-
-A semantics label for this image.

--- a/docs/controls/listtile.md
+++ b/docs/controls/listtile.md
@@ -88,6 +88,10 @@ ft.app(target=main)
 
 ## Properties
 
+### `autofocus`
+
+`True` if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
 ### `content_padding`
 
 The tile's internal padding. Insets a ListTile's contents: its `leading`, `title`, `subtitle`, and `trailing` controls.
@@ -96,23 +100,9 @@ If not set, `padding.symmetric(horizontal=16)` is used.
 
 See [`Container.padding`](container#padding) property for more information and possible values.
 
-### `leading`
+### `dense`
 
-A `Control` to display before the title.
-
-### `title`
-
-A `Control` to display as primary content of the list tile. Typically a [Text](text) control. This should not wrap. To enforce the single line limit, use [Text.max_lines](text#max_lines).
-
-### `subtitle`
-
-Additional content displayed below the title. Typically a [Text](text) widget.
-
-If `is_three_line` is `False`, this should not wrap. If `is_three_line` is `True`, this should be configured to take a maximum of two lines. For example, you can use [Text.max_lines](text#max_lines) to enforce the number of lines.
-
-### `trailing`
-
-A `Control` to display after the title. Typically an [Icon](icon) control.
+Whether this list tile is part of a vertically dense list. Dense list tiles default to a smaller height.
 
 ### `is_three_line`
 
@@ -124,17 +114,27 @@ If `False`, the list tile is treated as having one line if the subtitle is null 
 
 When using a Text control for title and subtitle, you can enforce line limits using [Text.max_lines](text#max_lines).
 
+### `leading`
+
+A `Control` to display before the title.
+
 ### `selected`
 
 If this tile is also enabled then icons and text are rendered with the same color. By default the selected color is the theme's primary color.
 
-### `dense`
+### `subtitle`
 
-Whether this list tile is part of a vertically dense list. Dense list tiles default to a smaller height.
+Additional content displayed below the title. Typically a [Text](text) widget.
 
-### `autofocus`
+If `is_three_line` is `False`, this should not wrap. If `is_three_line` is `True`, this should be configured to take a maximum of two lines. For example, you can use [Text.max_lines](text#max_lines) to enforce the number of lines.
 
-`True` if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+### `title`
+
+A `Control` to display as primary content of the list tile. Typically a [Text](text) control. This should not wrap. To enforce the single line limit, use [Text.max_lines](text#max_lines).
+
+### `trailing`
+
+A `Control` to display after the title. Typically an [Icon](icon) control.
 
 ## Events
 

--- a/docs/controls/listview.md
+++ b/docs/controls/listview.md
@@ -54,21 +54,29 @@ ft.app(target=main)
 
 ## Properties
 
+### `auto_scroll`
+
+`True` if scrollbar should automatically move its position to the end when children update.
+
 ### `controls`
 
 A list of `Control`s to display inside ListView.
+
+### `divider_thickness`
+
+If greater than `0` then Divider is used as a spacing between ListView items.
+
+### `first_item_prototype`
+
+`True` if the dimensions of the first item should be used as a "prototype" for all other items, i.e. their height or width will be the same as the first item. Default is `False`.
 
 ### `horizontal`
 
 `True` to layout ListView items horizontally.
 
-### `spacing`
+### `item_extent`
 
-The height of Divider between ListView items. No spacing between items if not specified.
-
-### `divider_thickness`
-
-If greater than `0` then Divider is used as a spacing between ListView items.
+A fixed height or width (for `horizontal` ListView) of an item to optimize rendering.
 
 ### `padding`
 
@@ -76,14 +84,6 @@ The amount of space by which to inset the children.
 
 See [`Container.padding`](container#padding) property for more information and possible values.
 
-### `auto_scroll`
+### `spacing`
 
-`True` if scrollbar should automatically move its position to the end when children update.
-
-### `item_extent`
-
-A fixed height or width (for `horizontal` ListView) of an item to optimize rendering.
-
-### `first_item_prototype`
-
-`True` if the dimensions of the first item should be used as a "prototype" for all other items, i.e. their height or width will be the same as the first item. Default is `False`.
+The height of Divider between ListView items. No spacing between items if not specified.

--- a/docs/controls/markdown.md
+++ b/docs/controls/markdown.md
@@ -120,13 +120,28 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
+### `code_style`
 
-Markdown content to render.
+Code block text style. An instance of `TextStyle` class.
 
-### `extension_set`
+An example of configuring monospace font for Markdown code blocks:
 
-Property value is `MarkdownExtensionSet` enum with the following values: `NONE` (default), `COMMON_MARK`, `GITHUB_WEB`, `GITHUB_FLAVORED`.
+```python
+    page.fonts = {
+        "Roboto Mono": "RobotoMono-VariableFont_wght.ttf",
+    }
+
+    page.add(
+        Markdown(
+            table,
+            selectable=True,
+            extension_set="gitHubWeb",
+            code_theme="atom-one-dark",
+            code_style=TextStyle(font_family="Roboto Mono"),
+            on_tap_link=lambda e: page.launch_url(e.data),
+        )
+    )
+```
 
 ### `code_theme`
 
@@ -225,32 +240,17 @@ Supported themes:
 * `xt256`
 * `zenburn`
 
-### `code_style`
+### `extension_set`
 
-Code block text style. An instance of `TextStyle` class.
-
-An example of configuring monospace font for Markdown code blocks:
-
-```python
-    page.fonts = {
-        "Roboto Mono": "RobotoMono-VariableFont_wght.ttf",
-    }
-
-    page.add(
-        Markdown(
-            table,
-            selectable=True,
-            extension_set="gitHubWeb",
-            code_theme="atom-one-dark",
-            code_style=TextStyle(font_family="Roboto Mono"),
-            on_tap_link=lambda e: page.launch_url(e.data),
-        )
-    )
-```
+Property value is `MarkdownExtensionSet` enum with the following values: `NONE` (default), `COMMON_MARK`, `GITHUB_WEB`, `GITHUB_FLAVORED`.
 
 ### `selectable`
 
 Whether rendered text is selectable or not.
+
+### `value`
+
+Markdown content to render.
 
 ## Events
 

--- a/docs/controls/matplotlibchart.md
+++ b/docs/controls/matplotlibchart.md
@@ -98,10 +98,6 @@ ft.app(target=main)
 
 Matplotlib figure to draw - an instance of `matplotlib.figure.Figure` class.
 
-### `original_size`
-
-`True` to display chart in original size. `False` (default) to display a chart that fits configured bounds.
-
 ### `isolated`
 
 Every time when a page or parent chart control are updated with `page.update()` or `Control.update()` methods respectively the chart is re-drawn by calling Matplotlib API. Frequent re-drawings of large charts could affect the performance of the entire Flet app.
@@ -129,3 +125,7 @@ def main(page: ft.Page):
 
 ft.app(target=main)
 ```
+
+### `original_size`
+
+`True` to display chart in original size. `False` (default) to display a chart that fits configured bounds.

--- a/docs/controls/navigationbar.md
+++ b/docs/controls/navigationbar.md
@@ -38,19 +38,19 @@ ft.app(target=main)
 
 ## `NavigationBar` properties
 
+### `bgcolor`
+
+The color of the NavigationBar itself.
+
 ### `destinations`
 
 Defines the appearance of the button items that are arrayed within the navigation bar.
 
 The value must be a list of two or more `NavigationDestination` instances.
 
-### `selected_index`
+### `elevation`
 
-The index into `destinations` for the current selected `NavigationDestination` or `None` if no destination is selected.
-
-### `bgcolor`
-
-The color of the NavigationBar itself.
+The elevation of the NavigationBar itself.
 
 ### `label_behavior`
 
@@ -64,9 +64,9 @@ Property value is `NavigationBarLabelBehavior` enum with the following values:
 * `ALWAYS_HIDE` - Never shows any of the labels under the navigation bar destinations, regardless of selected vs unselected.
 * `ONLY_SHOW_SELECTED` - Only shows the labels of the selected navigation bar destination. When a destination is unselected, the label will be faded out, and the icon will be centered. When a destination is selected, the label will fade in and the label and icon will slide up so that they are both centered.
 
-### `elevation`
+### `selected_index`
 
-The elevation of the NavigationBar itself.
+The index into `destinations` for the current selected `NavigationDestination` or `None` if no destination is selected.
 
 ## `NavigationBar` events
 
@@ -88,6 +88,10 @@ If `selected_icon_content` is provided, this will only be displayed when the des
 
 To make the NavigationBar more accessible, consider choosing an icon with a stroked and filled version, such as `icons.CLOUD` and `icons.CLOUD_QUEUE`. The icon should be set to the stroked version and `selected_icon` to the filled version.
 
+### `label`
+
+The text label that appears below the icon of this `NavigationDestination`.
+
 ### `selected_icon`
 
 The name of alternative icon displayed when this destination is selected.
@@ -97,7 +101,3 @@ The name of alternative icon displayed when this destination is selected.
 An alternative icon `Control` displayed when this destination is selected.
 
 If this icon is not provided, the NavigationBar will display `icon_content` in either state.
-
-### `label`
-
-The text label that appears below the icon of this `NavigationDestination`.

--- a/docs/controls/navigationrail.md
+++ b/docs/controls/navigationrail.md
@@ -65,15 +65,15 @@ ft.app(target=main)
 
 ## `NavigationRail` properties
 
+### `bgcolor`
+
+Sets the color of the Container that holds all of the NavigationRail's contents.
+
 ### `destinations`
 
 Defines the appearance of the button items that are arrayed within the navigation rail.
 
 The value must be a list of two or more `NavigationRailDestination` instances.
-
-### `selected_index`
-
-The index into `destinations` for the current selected `NavigationRailDestination` or `None` if no destination is selected.
 
 ### `extended`
 
@@ -87,50 +87,6 @@ If the rail is going to be in the extended state, then the `label_type` must be 
 
 The default value is `False`.
 
-### `label_type`
-
-Defines the layout and behavior of the labels for the default, unextended NavigationRail.
-
-When a navigation rail is extended, the labels are always shown.
-
-Property value is `NavigationRailLabelType` enum with the following values: `NONE` (default), `ALL`, `SELECTED`.
-
-### `bgcolor`
-
-Sets the color of the Container that holds all of the NavigationRail's contents.
-
-### `leading`
-
-An optional leading control in the rail that is placed above the destinations.
-
-Its location is not affected by `group_alignment`.
-
-This is commonly a [`FloatingActionButton`](floatingactionbutton), but may also be a non-button, such as a logo.
-
-### `trailing`
-
-An optional trailing control in the rail that is placed below the destinations.
-
-It's location is affected by `group_alignment`.
-
-This is commonly a list of additional options or destinations that is usually only rendered when `extended` is `True`.
-
-### `min_width`
-
-The smallest possible width for the rail regardless of the destination's icon or label size.
-
-The default is `72`.
-
-This value also defines the min width and min height of the destinations.
-
-To make a compact rail, set this to `56` and use `label_type='none'`.
-
-### `min_extended_width`
-
-The final width when the animation is complete for setting `extended` to `True`.
-
-The default value is `256`.
-
 ### `group_alignment`
 
 The vertical alignment for the group of destinations within the rail.
@@ -142,6 +98,50 @@ The value must be between `-1.0` and `1.0`.
 If `group_alignment` is `-1.0`, then the items are aligned to the top. If `group_alignment` is `0.0`, then the items are aligned to the center. If `group_alignment` is `1.0`, then the items are aligned to the bottom.
 
 The default is `-1.0`.
+
+### `label_type`
+
+Defines the layout and behavior of the labels for the default, unextended NavigationRail.
+
+When a navigation rail is extended, the labels are always shown.
+
+Property value is `NavigationRailLabelType` enum with the following values: `NONE` (default), `ALL`, `SELECTED`.
+
+### `leading`
+
+An optional leading control in the rail that is placed above the destinations.
+
+Its location is not affected by `group_alignment`.
+
+This is commonly a [`FloatingActionButton`](floatingactionbutton), but may also be a non-button, such as a logo.
+
+### `min_extended_width`
+
+The final width when the animation is complete for setting `extended` to `True`.
+
+The default value is `256`.
+
+### `min_width`
+
+The smallest possible width for the rail regardless of the destination's icon or label size.
+
+The default is `72`.
+
+This value also defines the min width and min height of the destinations.
+
+To make a compact rail, set this to `56` and use `label_type='none'`.
+
+### `selected_index`
+
+The index into `destinations` for the current selected `NavigationRailDestination` or `None` if no destination is selected.
+
+### `trailing`
+
+An optional trailing control in the rail that is placed below the destinations.
+
+Its location is affected by `group_alignment`.
+
+This is commonly a list of additional options or destinations that is usually only rendered when `extended` is `True`.
 
 ## `NavigationRail` events
 
@@ -163,16 +163,6 @@ If `selected_icon_content` is provided, this will only be displayed when the des
 
 To make the NavigationRail more accessible, consider choosing an icon with a stroked and filled version, such as `icons.CLOUD` and `icons.CLOUD_QUEUE`. The icon should be set to the stroked version and `selected_icon` to the filled version.
 
-### `selected_icon`
-
-The name of alternative icon displayed when this destination is selected.
-
-### `selected_icon_content`
-
-An alternative icon `Control` displayed when this destination is selected.
-
-If this icon is not provided, the NavigationRail will display `icon_content` in either state.
-
 ### `label`
 
 ### `label_content`
@@ -186,3 +176,13 @@ The label must be provided when used with the NavigationRail. When `label_type='
 The amount of space to inset the destination item.
 
 See [`Container.padding`](container#padding) for more information about padding and possible values.
+
+### `selected_icon`
+
+The name of alternative icon displayed when this destination is selected.
+
+### `selected_icon_content`
+
+An alternative icon `Control` displayed when this destination is selected.
+
+If this icon is not provided, the NavigationRail will display `icon_content` in either state.

--- a/docs/controls/outlinedbutton.md
+++ b/docs/controls/outlinedbutton.md
@@ -145,9 +145,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `text`
+### `autofocus`
 
-The text displayed on a button.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `content`
+
+A Control representing custom button content.
 
 ### `icon`
 
@@ -161,17 +165,13 @@ Icon color.
 
 See [ElevatedButton.style](elevatedbutton#style) for more information about this property.
 
+### `text`
+
+The text displayed on a button.
+
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
-### `content`
-
-A Control representing custom button content.
 
 ## Events
 
@@ -179,10 +179,10 @@ A Control representing custom button content.
 
 Fires when a user clicks the button.
 
-### `on_long_press`
-
-Fires when the button is long-pressed.
-
 ### `on_hover`
 
 Fires when a mouse pointer enters or exists the button response area. `data` property of event object contains `true` (string) when cursor enters and `false` when it exits.
+
+### `on_long_press`
+
+Fires when the button is long-pressed.

--- a/docs/controls/overview.md
+++ b/docs/controls/overview.md
@@ -30,33 +30,13 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 Flet controls have the following properties:
 
-### `width`
-
-Imposed Control width in virtual pixels.
-
-### `height`
-
-Imposed Control height in virtual pixels.
-
-### `left`
-
-Effective inside [`Stack`](controls/stack) only. The distance that the child's left edge is inset from the left of the stack.
-
-### `top`
-
-Effective inside [`Stack`](controls/stack) only. The distance that the child's top edge is inset from the top of the stack.
-
-### `right`
-
-Effective inside [`Stack`](controls/stack) only. The distance that the child's right edge is inset from the right of the stack.
-
 ### `bottom`
 
 Effective inside [`Stack`](controls/stack) only. The distance that the child's bottom edge is inset from the bottom of the stack.
 
-### `visible`
+### `data`
 
-Every control has `visible` property which is `True` by default - control is rendered on the page. Setting `visible` to `False` completely prevents control (and all its children if any) from rendering on a page canvas. Hidden controls cannot be focused or selected with a keyboard or mouse and they do not emit any events.
+Arbitrary data that can be attached to a control.
 
 ### `disabled`
 
@@ -81,64 +61,31 @@ When a child Control is placed into a [`Column`](controls/column) or [`Row`](con
 
 For more information and examples about `expand` property see "Expanding children" sections in [`Column`](controls/column#expanding-children) or [`Row`](controls/row#expanding-children).
 
-### `data`
+### `height`
 
-Arbitrary data that can be attached to a control.
+Imposed Control height in virtual pixels.
+
+### `left`
+
+Effective inside [`Stack`](controls/stack) only. The distance that the child's left edge is inset from the left of the stack.
+
+### `right`
+
+Effective inside [`Stack`](controls/stack) only. The distance that the child's right edge is inset from the right of the stack.
+
+### `top`
+
+Effective inside [`Stack`](controls/stack) only. The distance that the child's top edge is inset from the top of the stack.
+
+### `visible`
+
+Every control has `visible` property which is `True` by default - control is rendered on the page. Setting `visible` to `False` completely prevents control (and all its children if any) from rendering on a page canvas. Hidden controls cannot be focused or selected with a keyboard or mouse and they do not emit any events.
+
+### `width`
+
+Imposed Control width in virtual pixels.
 
 ## Transformations
-
-### `opacity`
-
-Makes a control partially transparent. `0.0` - control is completely transparent, not painted at all. `1.0` (default) - a control is fully painted without any transparency.
-
-### `scale`
-
-Scale control along the 2D plane. Default scale factor is `1.0` - control is not scaled. `0.5` - the control is twice smaller, `2.0` - the control is twice larger.
-
-Different scale multipliers can be specified for `x` and `y` axis, but setting `Control.scale` property to an instance of `transform.Scale` class:
-
-```python
-from dataclasses import field
-
-class Scale:
-    scale: float = field(default=None)
-    scale_x: float = field(default=None)
-    scale_y: float = field(default=None)
-    alignment: Alignment = field(default=None)
-```
-
-Either `scale` or `scale_x` and `scale_y` could be specified, but not all of them, for example:
-
-```python
-ft.Image(
-    src="https://picsum.photos/100/100",
-    width=100,
-    height=100,
-    border_radius=5,
-    scale=Scale(scale_x=2, scale_y=0.5)
-)
-```
-
-### `rotate`
-
-Transforms control using a rotation around the center.
-
-The value of `rotate` property could be one of the following types:
-
-* `number` - a rotation in clockwise radians. Full circle `360°` is `math.pi * 2` radians, `90°` is `pi / 2`, `45°` is `pi / 4`, etc.
-* `transform.Rotate` - allows to specify rotation `angle` as well as `alignment` - the location of rotation center.
-
-For example:
-
-```python
-ft.Image(
-    src="https://picsum.photos/100/100",
-    width=100,
-    height=100,
-    border_radius=5,
-    rotate=Rotate(angle=0.25 * pi, alignment=ft.alignment.center_left)
-)
-```
 
 ### `offset`
 
@@ -171,4 +118,57 @@ def main(page: ft.Page):
     )
 
 ft.app(target=main)
+```
+
+### `opacity`
+
+Makes a control partially transparent. `0.0` - control is completely transparent, not painted at all. `1.0` (default) - a control is fully painted without any transparency.
+
+### `rotate`
+
+Transforms control using a rotation around the center.
+
+The value of `rotate` property could be one of the following types:
+
+* `number` - a rotation in clockwise radians. Full circle `360°` is `math.pi * 2` radians, `90°` is `pi / 2`, `45°` is `pi / 4`, etc.
+* `transform.Rotate` - allows to specify rotation `angle` as well as `alignment` - the location of rotation center.
+
+For example:
+
+```python
+ft.Image(
+    src="https://picsum.photos/100/100",
+    width=100,
+    height=100,
+    border_radius=5,
+    rotate=Rotate(angle=0.25 * pi, alignment=ft.alignment.center_left)
+)
+```
+
+### `scale`
+
+Scale control along the 2D plane. Default scale factor is `1.0` - control is not scaled. `0.5` - the control is twice smaller, `2.0` - the control is twice larger.
+
+Different scale multipliers can be specified for `x` and `y` axis, but setting `Control.scale` property to an instance of `transform.Scale` class:
+
+```python
+from dataclasses import field
+
+class Scale:
+    scale: float = field(default=None)
+    scale_x: float = field(default=None)
+    scale_y: float = field(default=None)
+    alignment: Alignment = field(default=None)
+```
+
+Either `scale` or `scale_x` and `scale_y` could be specified, but not all of them, for example:
+
+```python
+ft.Image(
+    src="https://picsum.photos/100/100",
+    width=100,
+    height=100,
+    border_radius=5,
+    scale=Scale(scale_x=2, scale_y=0.5)
+)
 ```

--- a/docs/controls/page.md
+++ b/docs/controls/page.md
@@ -13,6 +13,24 @@ import TabItem from '@theme/TabItem';
 
 ## Properties
 
+### `auto_scroll`
+
+`True` if scrollbar should automatically move its position to the end when children update.
+
+### `appbar`
+
+A [`AppBar`](/docs/controls/appbar) control to display at the top of the Page.
+
+### `banner`
+
+A [`Banner`](/docs/controls/banner) control to display at the top of the Page.
+
+### `bgcolor`
+
+Background color of the Page.
+
+A color value could be a hex value in `#ARGB` format (e.g. `#FFCC0000`), `#RGB` format (e.g. `#CC0000`) or a named color from `flet.colors` module.
+
 ### `controls`
 
 A list of Controls to display on the Page.
@@ -55,193 +73,17 @@ page.update()
 </TabItem>
 </Tabs>
 
-### `views`
-
-A list of [`View`](view) controls to build navigation history.
-
-The last view in the list is the one displayed on a page.
-
-The first view is a "root" view which cannot be poped.
-
-### `title`
-
-A title of browser or native OS window, for example:
-
-<Tabs groupId="language">
-  <TabItem value="python" label="Python" default>
-
-```python
-page.title = "My awesome app"
-page.update()
-```
-
-</TabItem>
-</Tabs>
-
-### `route`
-
-Get or sets page's navigation route. See [Navigation and routing](/docs/guides/python/navigation-and-routing) section for 
-more information and examples.
-
-### `session_id`
-
-A unique ID of user's session. This property is read-only.
-
-### `pwa`
-
-`True` if the application is running as Progressive Web App (PWA). Read-only.
-
-### `web`
-
-`True` if the application is running in the web browser.
-
-### `platform`
-
-Operating system the application is running on:
-
-* `ios`
-* `android`
-* `macos`
-* `linux`
-* `windows`
-
-### `vertical_alignment`
-
-How the child Controls should be placed vertically.
-
-For example, `MainAxisAlignment.START`, the default, places the children at the top of a Page.
-
-Property value is `MainAxisAlignment` enum with the following values:
-
-* `START` (default)
-* `END`
-* `CENTER`
-* `SPACE_BETWEEN`
-* `SPACE_AROUND`
-* `SPACE_EVENLY`
-
-### `horizontal_alignment`
-
-How the child Controls should be placed horizontally.
-
-Default value is `CrossAxisAlignment.START` which means on the left side of the Page.
-
-Property value is `CrossAxisAlignment` enum with the following values:
-
-* `START` (default)
-* `CENTER`
-* `END`
-* `STRETCH`
-* `BASELINE`
-
-### `spacing`
-
-Vertical spacing between controls on the Page. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
-
-### `padding`
-
-A space between page contents and its edges. Default value is 10 pixels from each side. To set zero padding:
-
-<Tabs groupId="language">
-  <TabItem value="python" label="Python" default>
-
-```python
-page.padding = 0
-page.update()
-```
-
-</TabItem>
-</Tabs>
-
-See [`Container.padding`](container#padding) for more information and possible values.
-
-### `bgcolor`
-
-Background color of the Page.
-
-A color value could be a hex value in `#ARGB` format (e.g. `#FFCC0000`), `#RGB` format (e.g. `#CC0000`) or a named color from `flet.colors` module.
-
-### `scroll`
-
-Enables a vertical scrolling for the Page to prevent its content overflow.
-
-Property value is an optional `ScrollMode` enum with `None` as default.
-
-Supported values:
-
-* `None` (default) - the Row is non-scrollable and its content could overflow.
-* `AUTO` - scrolling is enabled and scroll bar is only shown when scrolling occurs.
-* `ADAPTIVE` - scrolling is enabled and scroll bar is always shown when running app as web or desktop.
-* `ALWAYS` - scrolling is enabled and scroll bar is always shown.
-* `HIDDEN` - scrolling is enabled, but scroll bar is always hidden.
-
-### `auto_scroll`
-
-`True` if scrollbar should automatically move its position to the end when children update.
-
-### `theme_mode`
-
-Page theme.
-
-Property value is an optional `ThemeMode` enum with `SYSTEM` as default.
-
-Supported values: `SYSTEM` (default), `LIGHT` or `DARK`.
-
-### `theme`
-
-Set this property to an instance of `theme.Theme` to customize light theme. Currently, a theme can only be automatically generated from a "seed" color. For example, to generate light theme from a green color:
-
-<Tabs groupId="language">
-  <TabItem value="python" label="Python" default>
-
-```python
-page.theme = theme.Theme(color_scheme_seed="green")
-page.update()
-```
-
-</TabItem>
-</Tabs>
-
-`Theme` class has the following properties:
-
-* `color_scheme_seed` - a seed color to algorithmically derive the rest of theme colors from.
-* `font_family` - the base font for all UI elements.
-* `use_material3` - `True` (default) to use Material 3 design; otherwise Material 2.
-* `visual_density` - `ThemeVisualDensity` enum: `STANDARD` (default), `COMPACT`, `COMFORTABLE`, `ADAPTIVE_PLATFORM_DENSITY`.
-* `page_transitions` - an instance of `PageTransitionsTheme` that allows customizing navigation page transitions for different platforms. See section [below](#navigation-transitions).
-
-:::note
-Read this [note about system fonts](/docs/controls/text#using-system-fonts) if you like to use them in `font_family` of your theme.
-:::
-
-#### Navigation transitions
-
-`theme.page_transitions` allows customizing navigation page transitions for different platforms. The value is an instance of `PageTransitionsTheme` class with the following optional properties:
-
-* `android` (default value is `FADE_UPWARDS`)
-* `ios` (default value is `CUPERTINO`)
-* `macos` (default value is `ZOOM`)
-* `linux` (default value is `ZOOM`)
-* `windows` (default value is `ZOOM`)
-
-Supported transitions is `PageTransitionTheme` enum: `FADE_UPWARDS`, `OPEN_UPWARDS`, `ZOOM`, `CUPERTINO`.
-
-An simple example:
-
-```python
-theme = Theme()
-theme.page_transitions.android = "openUpwards"
-theme.page_transitions.ios = "cupertino"
-theme.page_transitions.macos = "fadeUpwards"
-theme.page_transitions.linux = "zoom"
-theme.page_transitions.windows = "zoom"
-page.theme = theme
-page.update()
-```
-
 ### `dark_theme`
 
 Set this property to an instance of `theme.Theme` to customize dark theme.
+
+### `dialog`
+
+An [`AlertDialog`](/docs/controls/alertdialog) control to display.
+
+### `floating_action_button`
+
+A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to display on top of Page content.
 
 ### `fonts`
 
@@ -299,216 +141,54 @@ However, if you need to use a variable font in your app you can create static "i
 To explore available font features (e.g. possible options for `wght`) use [**Wakamai Fondue**](https://wakamaifondue.com/beta/) online tool.
 :::
 
-### `rtl`
+### `height`
 
-`True` to set text direction to right-to-left. Default is `False`.
+A height of a web page or content area of a native OS window containing Flet app. This property is read-only. It's usually being used inside [`page.on_resize`](#on_resize) handler.
 
-### `show_semantics_debugger`
+### `horizontal_alignment`
 
-`True` turns on an overlay that shows the accessibility information reported by the framework.
+How the child Controls should be placed horizontally.
+
+Default value is `CrossAxisAlignment.START` which means on the left side of the Page.
+
+Property value is `CrossAxisAlignment` enum with the following values:
+
+* `START` (default)
+* `CENTER`
+* `END`
+* `STRETCH`
+* `BASELINE`
 
 ### `overlay`
 
 A list of `Control`s displayed as a stack on top of main page contents.
 
-### `splash`
+### `padding`
 
-A `Control` that will be displayed on top of Page contents. [`ProgressBar`](/docs/controls/progressbar) or [`ProgressRing`](/docs/controls/progressring) could be used as an indicator for some lengthy operation, for example:
+A space between page contents and its edges. Default value is 10 pixels from each side. To set zero padding:
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python" default>
 
 ```python
-from time import sleep
-import flet as ft
-
-def main(page: ft.Page):
-    def button_click(e):
-        page.splash = ft.ProgressBar()
-        btn.disabled = True
-        page.update()
-        sleep(3)
-        page.splash = None
-        btn.disabled = False
-        page.update()
-
-    btn = ft.ElevatedButton("Do some lengthy task!", on_click=button_click)
-    page.add(btn)
-
-ft.app(target=main)
+page.padding = 0
+page.update()
 ```
 
 </TabItem>
 </Tabs>
 
-### `appbar`
+See [`Container.padding`](container#padding) for more information and possible values.
 
-A [`AppBar`](/docs/controls/appbar) control to display at the top of the Page.
+### `platform`
 
-### `floating_action_button`
+Operating system the application is running on:
 
-A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to display on top of Page content.
-
-### `banner`
-
-A [`Banner`](/docs/controls/banner) control to display at the top of the Page.
-
-### `dialog`
-
-An [`AlertDialog`](/docs/controls/alertdialog) control to display.
-
-### `width`
-
-A width of a web page or content area of a native OS window containing Flet app. This property is read-only. It's usually being used inside [`page.on_resize`](#on_resize) handler.
-
-### `height`
-
-A height of a web page or content area of a native OS window containing Flet app. This property is read-only. It's usually being used inside [`page.on_resize`](#on_resize) handler.
-
-### `window_bgcolor`
-
-🖥️ Desktop only. Sets background color of an application window.
-
-Use together with `page.bgcolor` to make a window transparent:
-
-```python
-import flet as ft
-
-def main(page: ft.Page):
-    page.window_bgcolor = ft.colors.TRANSPARENT
-    page.bgcolor = ft.colors.TRANSPARENT
-    page.window_title_bar_hidden = True
-    page.window_frameless = True
-    page.window_left = 400
-    page.window_top = 200
-    page.add(ft.ElevatedButton("I'm a floating button!"))
-
-ft.app(target=main)
-```
-
-### `window_width`
-
-🖥️ Desktop only. Get or set the width of a native OS window containing Flet app.
-
-### `window_height`
-
-🖥️ Desktop only. Get or set the height of a native OS window containing Flet app.
-
-### `window_top`
-
-🖥️ Desktop only. Get or set a vertical position of a native OS window - a distance in virtual pixels from the top edge of the screen.
-
-### `window_left`
-
-🖥️ Desktop only. Get or set a horizontal position of a native OS window - a distance in virtual pixels from the left edge of the screen.
-
-### `window_max_width`
-
-🖥️ Desktop only. Get or set the maximum width of a native OS window containing Flet app.
-
-### `window_max_height`
-
-🖥️ Desktop only. Get or set the maximum height of a native OS window containing Flet app.
-
-### `window_min_width`
-
-🖥️ Desktop only. Get or set the minimum width of a native OS window containing Flet app.
-
-### `window_min_height`
-
-🖥️ Desktop only. Get or set the minimum height of a native OS window containing Flet app.
-
-### `window_opacity`
-
-🖥️ Desktop only. Sets the opacity of a native OS window. The value must be between `0.0` (fully transparent) and `1.0` (fully opaque).
-
-### `window_maximized`
-
-🖥️ Desktop only. `True` if a native OS window containing Flet app is maximized; otherwise `False`. Set this property to `True` to programmatically maximize the window and set it to `False` to unmaximize it.
-
-### `window_minimized`
-
-🖥️ Desktop only. `True` if a native OS window containing Flet app is minimized; otherwise `False`. Set this property to `True` to programmatically minimize the window and set it to `False` to restore it.
-
-### `window_minimizable`
-
-🖥️ Desktop only. Set to `False` to hide/disable native OS window's "Minimize" button. Default is `True`.
-
-### `window_maximizable`
-
-🖥️ Desktop only. Set to `False` to hide/disable native OS window's "Maximize" button. Default is `True`.
-
-### `window_resizable`
-
-🖥️ Desktop only. Set to `False` to prevent user from resizing a native OS window containing Flet app. Default is `True`.
-
-### `window_movable`
-
-🖥️ Desktop only. macOS only. Set to `False` to prevent user from changing a position of a native OS window containing Flet app. Default is `True`.
-
-### `window_full_screen`
-
-🖥️ Desktop only. Set to `True` to switch app's native OS window to a fullscreen mode. Default is `False`.
-
-### `window_always_on_top`
-
-🖥️ Desktop only. Sets whether the window should show always on top of other windows. Default is `False`.
-
-### `window_prevent_close`
-
-🖥️ Desktop only. Set to `True` to intercept the native close signal. Could be used together with [`page.on_window_event (close)`](#on_window_event) event handler and [`page.window_destroy()`](#window_destroy) to implement app exit confirmation logic - see [`page.window_destroy()`](#window_destroy) for code example.
-
-### `window_focused`
-
-🖥️ Desktop only. Set to `True` to focus a native OS window with a Flet app.
-
-### `window_title_bar_hidden`
-
-🖥️ Desktop only. Set to `True` to hide window title bar. See [`WindowDragArea`](windowdragarea) control that allows moving
-an app window with hidden title bar.
-
-### `window_title_bar_buttons_hidden`
-
-🖥️ Desktop only. Set to `True` to hide window action buttons when a title bar is hidden. macOS only.
-
-### `window_frameless`
-
-🖥️ Desktop only. Set to `True` to make app window frameless.
-
-### `window_skip_task_bar`
-
-🖥️ Desktop only. Set to `True` to hide application from the Task Bar (Windows) or Dock (macOS).
-
-### `window_progress_bar`
-
-🖥️ Desktop only. The value from `0.0` to `1.0` to display a progress bar on Task Bar (Windows) or Dock (macOS) application button.
-
-### `window_visible`
-
-🖥️ Desktop only. Set to `True` to make application window visible. Used when the app is starting with a hidden window.
-
-The following program starts with a hidden window and makes it visible in 3 seconds:
-
-```python
-from time import sleep
-
-import flet as ft
-
-
-def main(page: ft.Page):
-
-    page.add(
-        ft.Text("Hello!")
-    )
-
-    sleep(3)
-    page.window_visible = True
-    page.update()  
-
-ft.app(target=main, view=ft.FLET_APP_HIDDEN)
-```
-
-Note `view=flet.FLET_APP_HIDDEN` which hides app window on start.
+* `ios`
+* `android`
+* `macos`
+* `linux`
+* `windows`
 
 ### `pubsub`
 
@@ -609,29 +289,347 @@ def main(page: ft.Page):
     page.on_close = client_exited
 ```
 
-## Methods
+### `pwa`
 
-### `go(route)`
+`True` if the application is running as Progressive Web App (PWA). Read-only.
 
-A helper method that updates [`page.route`](#route), calls [`page.on_route_change`](#on_route_change) event handler to update views and finally calls `page.update()`.
+### `route`
 
-### `set_clipboard(data)`
+Get or sets page's navigation route. See [Navigation and routing](/docs/guides/python/navigation-and-routing) section for 
+more information and examples.
 
-Set clipboard data on a client side (user's web browser or a desktop), for example:
+### `rtl`
+
+`True` to set text direction to right-to-left. Default is `False`.
+
+### `scroll`
+
+Enables a vertical scrolling for the Page to prevent its content overflow.
+
+Property value is an optional `ScrollMode` enum with `None` as default.
+
+Supported values:
+
+* `None` (default) - the Row is non-scrollable and its content could overflow.
+* `AUTO` - scrolling is enabled and scroll bar is only shown when scrolling occurs.
+* `ADAPTIVE` - scrolling is enabled and scroll bar is always shown when running app as web or desktop.
+* `ALWAYS` - scrolling is enabled and scroll bar is always shown.
+* `HIDDEN` - scrolling is enabled, but scroll bar is always hidden.
+
+### `session_id`
+
+A unique ID of user's session. This property is read-only.
+
+### `spacing`
+
+Vertical spacing between controls on the Page. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
+
+### `splash`
+
+A `Control` that will be displayed on top of Page contents. [`ProgressBar`](/docs/controls/progressbar) or [`ProgressRing`](/docs/controls/progressring) could be used as an indicator for some lengthy operation, for example:
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python" default>
 
 ```python
-page.set_clipboard("This value comes from Flet app")
+from time import sleep
+import flet as ft
+
+def main(page: ft.Page):
+    def button_click(e):
+        page.splash = ft.ProgressBar()
+        btn.disabled = True
+        page.update()
+        sleep(3)
+        page.splash = None
+        btn.disabled = False
+        page.update()
+
+    btn = ft.ElevatedButton("Do some lengthy task!", on_click=button_click)
+    page.add(btn)
+
+ft.app(target=main)
+```
+
+</TabItem>
+</Tabs>
+### `show_semantics_debugger`
+
+`True` turns on an overlay that shows the accessibility information reported by the framework.
+
+### `theme`
+
+Set this property to an instance of `theme.Theme` to customize light theme. Currently, a theme can only be automatically generated from a "seed" color. For example, to generate light theme from a green color:
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+
+```python
+page.theme = theme.Theme(color_scheme_seed="green")
+page.update()
 ```
 
 </TabItem>
 </Tabs>
 
+`Theme` class has the following properties:
+
+* `color_scheme_seed` - a seed color to algorithmically derive the rest of theme colors from.
+* `font_family` - the base font for all UI elements.
+* `use_material3` - `True` (default) to use Material 3 design; otherwise Material 2.
+* `visual_density` - `ThemeVisualDensity` enum: `STANDARD` (default), `COMPACT`, `COMFORTABLE`, `ADAPTIVE_PLATFORM_DENSITY`.
+* `page_transitions` - an instance of `PageTransitionsTheme` that allows customizing navigation page transitions for different platforms. See section [below](#navigation-transitions).
+
+:::note
+Read this [note about system fonts](/docs/controls/text#using-system-fonts) if you like to use them in `font_family` of your theme.
+:::
+
+#### Navigation transitions
+
+`theme.page_transitions` allows customizing navigation page transitions for different platforms. The value is an instance of `PageTransitionsTheme` class with the following optional properties:
+
+* `android` (default value is `FADE_UPWARDS`)
+* `ios` (default value is `CUPERTINO`)
+* `macos` (default value is `ZOOM`)
+* `linux` (default value is `ZOOM`)
+* `windows` (default value is `ZOOM`)
+
+Supported transitions is `PageTransitionTheme` enum: `FADE_UPWARDS`, `OPEN_UPWARDS`, `ZOOM`, `CUPERTINO`.
+
+An simple example:
+
+```python
+theme = Theme()
+theme.page_transitions.android = "openUpwards"
+theme.page_transitions.ios = "cupertino"
+theme.page_transitions.macos = "fadeUpwards"
+theme.page_transitions.linux = "zoom"
+theme.page_transitions.windows = "zoom"
+page.theme = theme
+page.update()
+```
+
+### `theme_mode`
+
+Page theme.
+
+Property value is an optional `ThemeMode` enum with `SYSTEM` as default.
+
+Supported values: `SYSTEM` (default), `LIGHT` or `DARK`.
+
+### `title`
+
+A title of browser or native OS window, for example:
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
+
+```python
+page.title = "My awesome app"
+page.update()
+```
+
+</TabItem>
+</Tabs>
+
+### `vertical_alignment`
+
+How the child Controls should be placed vertically.
+
+For example, `MainAxisAlignment.START`, the default, places the children at the top of a Page.
+
+Property value is `MainAxisAlignment` enum with the following values:
+
+* `START` (default)
+* `END`
+* `CENTER`
+* `SPACE_BETWEEN`
+* `SPACE_AROUND`
+* `SPACE_EVENLY`
+
+### `views`
+
+A list of [`View`](view) controls to build navigation history.
+
+The last view in the list is the one displayed on a page.
+
+The first view is a "root" view which cannot be poped.
+
+### `web`
+
+`True` if the application is running in the web browser.
+
+### `width`
+
+A width of a web page or content area of a native OS window containing Flet app. This property is read-only. It's usually being used inside [`page.on_resize`](#on_resize) handler.
+
+### `window_always_on_top`
+
+🖥️ Desktop only. Sets whether the window should show always on top of other windows. Default is `False`.
+
+### `window_bgcolor`
+
+🖥️ Desktop only. Sets background color of an application window.
+
+Use together with `page.bgcolor` to make a window transparent:
+
+```python
+import flet as ft
+
+def main(page: ft.Page):
+    page.window_bgcolor = ft.colors.TRANSPARENT
+    page.bgcolor = ft.colors.TRANSPARENT
+    page.window_title_bar_hidden = True
+    page.window_frameless = True
+    page.window_left = 400
+    page.window_top = 200
+    page.add(ft.ElevatedButton("I'm a floating button!"))
+
+ft.app(target=main)
+```
+
+### `window_focused`
+
+🖥️ Desktop only. Set to `True` to focus a native OS window with a Flet app.
+
+### `window_frameless`
+
+🖥️ Desktop only. Set to `True` to make app window frameless.
+
+### `window_full_screen`
+
+🖥️ Desktop only. Set to `True` to switch app's native OS window to a fullscreen mode. Default is `False`.
+
+### `window_height`
+
+🖥️ Desktop only. Get or set the height of a native OS window containing Flet app.
+
+### `window_left`
+
+🖥️ Desktop only. Get or set a horizontal position of a native OS window - a distance in virtual pixels from the left edge of the screen.
+
+### `window_maximizable`
+
+🖥️ Desktop only. Set to `False` to hide/disable native OS window's "Maximize" button. Default is `True`.
+
+### `window_maximized`
+
+🖥️ Desktop only. `True` if a native OS window containing Flet app is maximized; otherwise `False`. Set this property to `True` to programmatically maximize the window and set it to `False` to unmaximize it.
+
+### `window_max_height`
+
+🖥️ Desktop only. Get or set the maximum height of a native OS window containing Flet app.
+
+### `window_max_width`
+
+🖥️ Desktop only. Get or set the maximum width of a native OS window containing Flet app.
+
+### `window_minimizable`
+
+🖥️ Desktop only. Set to `False` to hide/disable native OS window's "Minimize" button. Default is `True`.
+
+### `window_minimized`
+
+🖥️ Desktop only. `True` if a native OS window containing Flet app is minimized; otherwise `False`. Set this property to `True` to programmatically minimize the window and set it to `False` to restore it.
+
+### `window_min_height`
+
+🖥️ Desktop only. Get or set the minimum height of a native OS window containing Flet app.
+
+### `window_min_width`
+
+🖥️ Desktop only. Get or set the minimum width of a native OS window containing Flet app.
+
+### `window_movable`
+
+🖥️ Desktop only. macOS only. Set to `False` to prevent user from changing a position of a native OS window containing Flet app. Default is `True`.
+
+### `window_opacity`
+
+🖥️ Desktop only. Sets the opacity of a native OS window. The value must be between `0.0` (fully transparent) and `1.0` (fully opaque).
+
+### `window_resizable`
+
+🖥️ Desktop only. Set to `False` to prevent user from resizing a native OS window containing Flet app. Default is `True`.
+
+### `window_title_bar_hidden`
+
+🖥️ Desktop only. Set to `True` to hide window title bar. See [`WindowDragArea`](windowdragarea) control that allows moving
+an app window with hidden title bar.
+
+### `window_title_bar_buttons_hidden`
+
+🖥️ Desktop only. Set to `True` to hide window action buttons when a title bar is hidden. macOS only.
+
+### `window_top`
+
+🖥️ Desktop only. Get or set a vertical position of a native OS window - a distance in virtual pixels from the top edge of the screen.
+
+### `window_prevent_close`
+
+🖥️ Desktop only. Set to `True` to intercept the native close signal. Could be used together with [`page.on_window_event (close)`](#on_window_event) event handler and [`page.window_destroy()`](#window_destroy) to implement app exit confirmation logic - see [`page.window_destroy()`](#window_destroy) for code example.
+
+### `window_progress_bar`
+
+🖥️ Desktop only. The value from `0.0` to `1.0` to display a progress bar on Task Bar (Windows) or Dock (macOS) application button.
+
+### `window_skip_task_bar`
+
+🖥️ Desktop only. Set to `True` to hide application from the Task Bar (Windows) or Dock (macOS).
+
+### `window_visible`
+
+🖥️ Desktop only. Set to `True` to make application window visible. Used when the app is starting with a hidden window.
+
+The following program starts with a hidden window and makes it visible in 3 seconds:
+
+```python
+from time import sleep
+
+import flet as ft
+
+
+def main(page: ft.Page):
+
+    page.add(
+        ft.Text("Hello!")
+    )
+
+    sleep(3)
+    page.window_visible = True
+    page.update()  
+
+ft.app(target=main, view=ft.FLET_APP_HIDDEN)
+```
+
+Note `view=flet.FLET_APP_HIDDEN` which hides app window on start.
+
+### `window_width`
+
+🖥️ Desktop only. Get or set the width of a native OS window containing Flet app.
+
+## Methods
+
+### `can_launch_url(url)`
+
+Checks whether the specified URL can be handled by some app installed on the device.
+
+Returns `True` if it is possible to verify that there is a handler available. A `False` return value can indicate either that there is no handler available, or that the application does not have permission to check. For example:
+
+* On recent versions of Android and iOS, this will always return `False` unless the application has been configuration to allow querying the system for launch support.
+* On web, this will always return `False` except for a few specific schemes that are always assumed to be supported (such as http(s)), as web pages are never allowed to query installed applications.
+
+### `close_in_app_web_view()`
+
+📱 Mobile only. Closes in-app web view opened with `launch_url()`.
+
 ### `get_clipboard()`
 
 Get the last text value saved to a clipboard on a client side.
+
+### `go(route)`
+
+A helper method that updates [`page.route`](#route), calls [`page.on_route_change`](#on_route_change) event handler to update views and finally calls `page.update()`.
 
 ### `launch_url(url)`
 
@@ -643,21 +641,6 @@ Optional method arguments:
 * `web_popup_window` - set to `True` to display a URL in a browser popup window. Default is `False`.
 * `window_width` - optional, popup window width.
 * `window_height` - optional, popup window height.
-
-### `can_launch_url(url)`
-
-Checks whether the specified URL can be handled by some app installed on the device.
-
-Returns `True` if it is possible to verify that there is a handler available. A `False` return value can indicate either that there is no handler available, or that the application does not have permission to check. For example:
-
-* On recent versions of Android and iOS, this will always return `False` unless the application has been configuration to allow querying the system for launch support.
-* On web, this will always return `False` except for a few specific schemes that are always assumed to be supported (such as http(s)), as web pages are never allowed to query installed applications.
-
-### `show_snack_bar(snack_bar)`
-
-Displays SnackBar at the bottom of the page.
-
-`snack_bar` - A [`SnackBar`](/docs/controls/snackbar) control to display at the bottom of the Page.
 
 ### `page.get_upload_url(file_name, expires)`
 
@@ -678,13 +661,25 @@ To enable built-in upload storage provide `upload_dir` argument to `flet.app()` 
 ft.app(target=main, upload_dir="uploads")
 ```
 
-### `close_in_app_web_view()`
+### `set_clipboard(data)`
 
-📱 Mobile only. Closes in-app web view opened with `launch_url()`.
+Set clipboard data on a client side (user's web browser or a desktop), for example:
 
-### `window_to_front()`
+<Tabs groupId="language">
+  <TabItem value="python" label="Python" default>
 
-🖥️ Desktop only. Brings application window to a foreground.
+```python
+page.set_clipboard("This value comes from Flet app")
+```
+
+</TabItem>
+</Tabs>
+
+### `show_snack_bar(snack_bar)`
+
+Displays SnackBar at the bottom of the page.
+
+`snack_bar` - A [`SnackBar`](/docs/controls/snackbar) control to display at the bottom of the Page.
 
 ### `window_center()`
 
@@ -736,7 +731,43 @@ def main(page: ft.Page):
 ft.app(target=main)
 ```
 
+### `window_to_front()`
+
+🖥️ Desktop only. Brings application window to a foreground.
+
 ## Events
+
+### `on_close`
+
+Fires when a session has expired after configured amount of time (60 minutes by default).
+
+### `on_connect`
+
+Fires when a web user (re-)connects to a page session. It is not triggered when an app page is first opened, but is triggered when the page is refreshed, or Flet web client has re-connected after computer was unlocked. This event could be used to detect when a web user becomes "online".
+
+### `on_disconnect`
+
+Fires when a web user disconnects from a page session, i.e. closes browser tab/window.
+
+### `on_error`
+
+Fires when unhandled exception occurs.
+
+### `on_keyboard_event`
+
+Fires when a keyboard key is pressed. Event object `e` is an instance of `KeyboardEvent` class:
+
+```python
+@dataclass
+class ft.KeyboardEvent:
+    key: str
+    shift: bool
+    ctrl: bool
+    alt: bool
+    meta: bool
+```
+
+Check a [simple usage example](https://github.com/flet-dev/examples/blob/main/python/controls/page/keyboard-events.py).
 
 ### `on_resize`
 
@@ -754,6 +785,30 @@ page.on_resize = page_resize
 
 </TabItem>
 </Tabs>
+
+### `on_route_change`
+
+Fires when page route changes either programmatically, by editing application URL or using browser Back/Forward buttons.
+
+Event object `e` is an instance of `RouteChangeEvent` class:
+
+```python
+class RouteChangeEvent(ft.ControlEvent):
+    route: str     # a new page root
+```
+
+### `on_view_pop`
+
+Fires when the user clicks automatic "Back" button in [`AppBar`](/docs/controls/appbar) control.
+
+Event object `e` is an instance of `ViewPopEvent` class:
+
+```python
+class ViewPopEvent(ft.ControlEvent):
+    view: ft.View
+```
+
+where `view` is an instance of [`View`](/docs/controls/view) control that contains the AppBar.
 
 ### `on_window_event`
 
@@ -774,59 +829,3 @@ Fires when an application's native OS window changes its state: position, size, 
 * `moved` (macOS and Windows only)
 * `enterFullScreen`
 * `leaveFullScreen`
-
-### `on_keyboard_event`
-
-Fires when a keyboard key is pressed. Event object `e` is an instance of `KeyboardEvent` class:
-
-```python
-@dataclass
-class ft.KeyboardEvent:
-    key: str
-    shift: bool
-    ctrl: bool
-    alt: bool
-    meta: bool
-```
-
-Check a [simple usage example](https://github.com/flet-dev/examples/blob/main/python/controls/page/keyboard-events.py).
-
-### `on_route_change`
-
-Fires when page route changes either programmatically, by editing application URL or using browser Back/Forward buttons.
-
-Event object `e` is an instance of `RouteChangeEvent` class:
-
-```python
-class RouteChangeEvent(ControlEvent):
-    route: str     # a new page root
-```
-
-### `on_view_pop`
-
-Fires when the user clicks automatic "Back" button in [`AppBar`](/docs/controls/appbar) control.
-
-Event object `e` is an instance of `ViewPopEvent` class:
-
-```python
-class ViewPopEvent(ControlEvent):
-    view: View
-```
-
-where `view` is an instance of [`View`](/docs/controls/view) control that contains the AppBar.
-
-### `on_connect`
-
-Fires when a web user (re-)connects to a page session. It is not triggered when an app page is first opened, but is triggered when the page is refreshed, or Flet web client has re-connected after computer was unlocked. This event could be used to detect when a web user becomes "online".
-
-### `on_disconnect`
-
-Fires when a web user disconnects from a page session, i.e. closes browser tab/window.
-
-### `on_close`
-
-Fires when a session has expired after configured amount of time (60 minutes by default).
-
-### `on_error`
-
-Fires when unhandled exception occurs.

--- a/docs/controls/progressring.md
+++ b/docs/controls/progressring.md
@@ -52,22 +52,22 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
+### `bgcolor`
 
-The value of this progress indicator. A value of 0.0 means no progress and 1.0 means that progress is complete. The value will be clamped to be in the range 0.0-1.0. If null, this progress indicator is indeterminate, which means the indicator displays a predetermined animation that does not indicate how much actual progress is being made.
-
-### `stroke_width`
-
-The width of the line used to draw the circle.
+Color of the circular track being filled by the circular indicator.
 
 ### `color`
 
 The progress indicator's color.
 
-### `bgcolor`
+### `stroke_width`
 
-Color of the circular track being filled by the circular indicator.
+The width of the line used to draw the circle.
 
 ### `tooltip`
 
 The text displayed when hovering the mouse over the control.
+
+### `value`
+
+The value of this progress indicator. A value of 0.0 means no progress and 1.0 means that progress is complete. The value will be clamped to be in the range 0.0-1.0. If null, this progress indicator is indeterminate, which means the indicator displays a predetermined animation that does not indicate how much actual progress is being made.

--- a/docs/controls/radio.md
+++ b/docs/controls/radio.md
@@ -82,18 +82,6 @@ Fires when the state of the RadioGroup is changed.
 
 ## `Radio` properties
 
-### `value`
-
-The value to set to containing `RadioGroup` when the radio is selected..
-
-### `label`
-
-The clickable label to display on the right of a Radio.
-
-### `label_position`
-
-Property value is `LabelPosition` enum with `LabelPosition.RIGHT` as default.
-
 ### `autofocus`
 
 True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
@@ -128,12 +116,24 @@ rd.fill_color={
 }
 ```
 
+### `label`
+
+The clickable label to display on the right of a Radio.
+
+### `label_position`
+
+Property value is `LabelPosition` enum with `LabelPosition.RIGHT` as default.
+
+### `value`
+
+The value to set to containing `RadioGroup` when the radio is selected.
+
 ## `Radio` events
-
-### `on_focus`
-
-Fires when the control has received focus.
 
 ### `on_blur`
 
 Fires when the control has lost focus.
+
+### `on_focus`
+
+Fires when the control has received focus.

--- a/docs/controls/responsiverow.md
+++ b/docs/controls/responsiverow.md
@@ -116,14 +116,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `controls`
-
-A list of Controls to display inside the ResponsiveRow.
-
-### `columns`
-
-The numner of virtual columns to layout children. Default is 12.
-
 ### `alignment`
 
 How the child Controls should be placed horizontally.
@@ -139,6 +131,22 @@ Property value is `MainAxisAlignment` enum with the following values:
 * `SPACE_AROUND`
 * `SPACE_EVENLY`
 
+### `columns`
+
+The number of virtual columns to layout children. Default is 12.
+
+### `controls`
+
+A list of Controls to display inside the ResponsiveRow.
+
+### `run_spacing`
+
+Spacing between runs when row content is wrapped on multiple lines. Default value is 10.
+
+### `spacing`
+
+Spacing between controls in a row. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
+
 ### `vertical_alignment`
 
 How the child Controls should be placed vertically.
@@ -150,11 +158,3 @@ Property value is `CrossAxisAlignment` enum with the following values:
 * `END`
 * `STRETCH`
 * `BASELINE`
-
-### `spacing`
-
-Spacing between controls in a row. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
-
-### `run_spacing`
-
-Spacing between runs when row content is wrapped on multiple lines. Default value is 10.

--- a/docs/controls/row.md
+++ b/docs/controls/row.md
@@ -226,10 +226,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `controls`
-
-A list of Controls to display inside the Row.
-
 ### `alignment`
 
 How the child Controls should be placed horizontally.
@@ -245,29 +241,13 @@ Property value is `MainAxisAlignment` enum with the following values:
 * `SPACE_AROUND`
 * `SPACE_EVENLY`
 
-### `vertical_alignment`
+### `auto_scroll`
 
-How the child Controls should be placed vertically.
+`True` if scrollbar should automatically move its position to the end when children update.
 
-Property value is `CrossAxisAlignment` enum with the following values:
+### `controls`
 
-* `START` (default)
-* `CENTER`
-* `END`
-* `STRETCH`
-* `BASELINE`
-
-### `tight`
-
-Specifies how much space should be occupied horizontally. Default is `False` - allocate all space to children.
-
-### `spacing`
-
-Spacing between controls in a row. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
-
-### `wrap`
-
-When set to `True` the Row will put child controls into additional rows (runs) if they don't fit a single row.
+A list of Controls to display inside the Row.
 
 ### `run_spacing`
 
@@ -287,9 +267,29 @@ Supported values:
 * `ALWAYS` - scrolling is enabled and scroll bar is always shown.
 * `HIDDEN` - scrolling is enabled, but scroll bar is always hidden.
 
-### `auto_scroll`
+### `spacing`
 
-`True` if scrollbar should automatically move its position to the end when children update.
+Spacing between controls in a row. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
+
+### `tight`
+
+Specifies how much space should be occupied horizontally. Default is `False` - allocate all space to children.
+
+### `vertical_alignment`
+
+How the child Controls should be placed vertically.
+
+Property value is `CrossAxisAlignment` enum with the following values:
+
+* `START` (default)
+* `CENTER`
+* `END`
+* `STRETCH`
+* `BASELINE`
+
+### `wrap`
+
+When set to `True` the Row will put child controls into additional rows (runs) if they don't fit a single row.
 
 ## Expanding children
 

--- a/docs/controls/shadermask.md
+++ b/docs/controls/shadermask.md
@@ -89,10 +89,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `content`
-
-A child `Control` to apply a shader to.
-
 ### `blend_mode`
 
 The blend mode to use when applying the shader to the `content`.
@@ -134,10 +130,14 @@ Supported values:
 
 See [BlendMode](https://api.flutter.dev/flutter/dart-ui/BlendMode.html) from Flutter documentation for blend mode examples.
 
-### `shader`
-
-Use gradient as a shader. See [`Container.gradient`](container#gradient) property docs for more information about gradients.
-
 ### `border_radius`
 
 See [`Container.border_radius`](container#border_radius) property docs for more information about border radius.
+
+### `content`
+
+A child `Control` to apply a shader to.
+
+### `shader`
+
+Use gradient as a shader. See [`Container.gradient`](container#gradient) property docs for more information about gradients.

--- a/docs/controls/shakedetector.md
+++ b/docs/controls/shakedetector.md
@@ -35,13 +35,13 @@ ft.app(target=main)
 
 Number of shakes required before shake is triggered. Default is `1`.
 
-### `shake_slop_time_ms`
-
-Minimum time between shakes, in milliseconds. Default is `500` ms.
-
 ### `shake_count_reset_time_ms`
 
 Time, in milliseconds, before shake count resets. Default is `3000` ms.
+
+### `shake_slop_time_ms`
+
+Minimum time between shakes, in milliseconds. Default is `500` ms.
 
 ### `shake_threshold_gravity`
 

--- a/docs/controls/slider.md
+++ b/docs/controls/slider.md
@@ -83,27 +83,15 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
+### `active_color`
 
-The currently selected value for this slider.
+The color to use for the portion of the slider track that is active.
 
-The slider's thumb is drawn at a position that corresponds to this value.
+The "active" side of the slider is the side between the thumb and the minimum value.
 
-### `min`
+### `autofocus`
 
-The minimum value the user can select.
-
-Defaults to `0.0`. Must be less than or equal to `max`.
-
-If the `max` is equal to the `min`, then the slider is disabled.
-
-### `max`
-
-The maximum value the user can select.
-
-Defaults to `1.0`. Must be greater than or equal to `min`.
-
-If the `max` is equal to the `min`, then the slider is disabled.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
 
 ### `divisions`
 
@@ -112,6 +100,12 @@ The number of discrete divisions.
 Typically used with `label` to show the current discrete value.
 
 If not set, the slider is continuous.
+
+### `inactive_color`
+
+The color for the inactive portion of the slider track.
+
+The "inactive" side of the slider is the side between the thumb and the maximum value.
 
 ### `label`
 
@@ -123,44 +117,50 @@ It is used to display the value of a discrete slider, and it is displayed as par
 
 If not set, then the value indicator will not be displayed.
 
-### `autofocus`
+### `max`
 
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+The maximum value the user can select.
 
-### `active_color`
+Defaults to `1.0`. Must be greater than or equal to `min`.
 
-The color to use for the portion of the slider track that is active.
+If the `max` is equal to the `min`, then the slider is disabled.
 
-The "active" side of the slider is the side between the thumb and the minimum value.
+### `min`
 
-### `inactive_color`
+The minimum value the user can select.
 
-The color for the inactive portion of the slider track.
+Defaults to `0.0`. Must be less than or equal to `max`.
 
-The "inactive" side of the slider is the side between the thumb and the maximum value.
+If the `max` is equal to the `min`, then the slider is disabled.
 
 ### `thumb_color`
 
 The color of the thumb.
 
+### `value`
+
+The currently selected value for this slider.
+
+The slider's thumb is drawn at a position that corresponds to this value.
+
 ## Events
+
+### `on_blur`
+
+Fires when the control has lost focus.
 
 ### `on_change`
 
 Fires when the state of the Slider is changed.
 
-### `on_change_start`
-
-Fires when the user starts selecting a new value for the slider.
-
 ### `on_change_end`
 
 Fires when the user is done selecting a new value for the slider.
 
+### `on_change_start`
+
+Fires when the user starts selecting a new value for the slider.
+
 ### `on_focus`
 
 Fires when the control has received focus.
-
-### `on_blur`
-
-Fires when the control has lost focus.

--- a/docs/controls/snackbar.md
+++ b/docs/controls/snackbar.md
@@ -49,14 +49,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `open`
-
-Set to `True` to display a SnackBar. This property is automatically set to `False` once SnackBar is shown.
-
-### `content`
-
-The primary content of the snack bar. Typically a [`Text`](text) control.
-
 ### `action`
 
 An optional action that the user can take based on the snack bar.
@@ -65,13 +57,21 @@ For example, the snack bar might let the user undo the operation that prompted t
 
 The action should not be "dismiss" or "cancel".
 
+### `action_color`
+
+The foreground color of action button.
+
 ### `bgcolor`
 
 SnackBar background color.
 
-### `action_color`
+### `content`
 
-The foreground color of action button.
+The primary content of the snack bar. Typically a [`Text`](text) control.
+
+### `open`
+
+Set to `True` to display a SnackBar. This property is automatically set to `False` once SnackBar is shown.
 
 ## Events
 

--- a/docs/controls/stack.md
+++ b/docs/controls/stack.md
@@ -163,10 +163,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `controls`
-
-A list of Controls to display inside the Stack. The last control in the list is displayed on top.
-
 ### `clip_behavior`
 
 The content will be clipped (or not) according to this option.
@@ -177,3 +173,7 @@ Property value is `ClipBehavior` enum with supported values:
 * `ANTI_ALIAS`
 * `ANTI_ALIAS_WITH_SAVE_LAYER`
 * `HARD_EDGE` (default)
+
+### `controls`
+
+A list of Controls to display inside the Stack. The last control in the list is displayed on top.

--- a/docs/controls/switch.md
+++ b/docs/controls/switch.md
@@ -78,22 +78,6 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
-
-Current value of the Switch.
-
-### `label`
-
-The clickable label to display on the right of the Switch.
-
-### `label_position`
-
-Property value is `LabelPosition` enum with `LabelPosition.RIGHT` as default.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
 ### `active_color`
 
 The color to use when this switch is on.
@@ -103,6 +87,10 @@ The color to use when this switch is on.
 The color to use on the track when this switch is on.
 
 If `track_color` returns a non-null color in the `selected` state, it will be used instead of this color.
+
+### `autofocus`
+
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
 
 ### `inactive_thumb_color`
 
@@ -115,6 +103,14 @@ If `thumb_color` returns a non-null color in the default state, it will be used 
 The color to use on the track when this switch is off.
 
 If `track_color` returns a non-null color in the default state, it will be used instead of this color.
+
+### `label`
+
+The clickable label to display on the right of the Switch.
+
+### `label_position`
+
+Property value is `LabelPosition` enum with `LabelPosition.RIGHT` as default.
 
 ### `thumb_color`
 
@@ -131,16 +127,16 @@ Resolved in the following `MaterialState` states:
 To configure thumb color for all Material states set `thumb_color` value to a literal, for example:
 
 ```python
-sw.thumb_color=colors.GREEN
+sw.thumb_color=ft.colors.GREEN
 ```
 
 To configure thumb color for specific Material states set its value to a dictionary where the key is state name. For example, to configure different fill colors for `HOVERED` and `FOCUSED` states and another color for all other states:
 
 ```python
 sw.thumb_color={
-    ft.MaterialState.HOVERED: colors.GREEN,
-    ft.MaterialState.FOCUSED: colors.RED,
-    ft.MaterialState.DEFAULT: colors.BLACK,
+    ft.MaterialState.HOVERED: ft.colors.GREEN,
+    ft.MaterialState.FOCUSED: ft.colors.RED,
+    ft.MaterialState.DEFAULT: ft.colors.BLACK,
 }
 ```
 
@@ -156,7 +152,15 @@ Resolved in the following `MaterialState` states:
 * `DISABLED`
 * `DEFAULT` - fallback state, meaning "all other states".
 
+### `value`
+
+Current value of the Switch.
+
 ## Events
+
+### `on_blur`
+
+Fires when the control has lost focus.
 
 ### `on_change`
 
@@ -165,7 +169,3 @@ Fires when the state of the Switch is changed.
 ### `on_focus`
 
 Fires when the control has received focus.
-
-### `on_blur`
-
-Fires when the control has lost focus.

--- a/docs/controls/tabs.md
+++ b/docs/controls/tabs.md
@@ -55,17 +55,17 @@ ft.app(target=main)
 
 ## `Tabs` properties
 
-### `tabs`
+### `animation_duration`
 
-A list of `Tab` controls.
+Duration of animation in milliseconds of swtiching between tabs. Default is `50`.
 
 ### `selected_index`
 
 The index of currently selected tab.
 
-### `animation_duration`
+### `tabs`
 
-Duration of animation in milliseconds of swtiching between tabs. Default is `50`.
+A list of `Tab` controls.
 
 ## `Tabs` events
 
@@ -75,18 +75,18 @@ Fires when `selected_index` changes.
 
 ## `Tab` properties
 
-### `text`
+### `content`
 
-Tab's display name.
+A `Control` to display below the Tab when it is selected.
 
 ### `icon`
 
 An icon to display on the left of Tab text.
 
-### `content`
-
-A `Control` to display below the Tab when it is selected.
-
 ### `tab_content`
 
 A `Control` representing custom tab content replacing `text` and `icon`.
+
+### `text`
+
+Tab's display name.

--- a/docs/controls/text.md
+++ b/docs/controls/text.md
@@ -157,34 +157,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
+### `bgcolor`
 
-The text displayed.
+Text background color.
 
-### `semantics_label`
+### `color`
 
-An alternative semantics label for this text.
-
-If present, the semantics of this control will contain this value instead of the actual text.
-
-This is useful for replacing abbreviations or shorthands with the full text value:
-
-```python
-Text("$$", semantics_label="Double dollars")
-```
-
-### `text_align`
-
-Text horizontal align.
-
-Property value is `TextAlign` enum with the following values:
-
-* `LEFT` (default)
-* `RIGHT`
-* `CENTER`
-* `JUSTIFY`
-* `START`
-* `END`
+Text foreground color.
 
 ### `font_family`
 
@@ -229,37 +208,50 @@ Supported `web_renderer` values:
 * `html` - optimizing download size over performance on both desktop and mobile browsers.
 * `auto` - optimizing for download size on mobile browsers and optimizing for performance on desktop browsers.
 
-### `size`
-
-Text size in virtual pixels. Default is `14`.
-
-### `weight`
-
-Font weight.
-
-Property value is `FontWeight` enum with the following values:
-
-* `NORMAL` (default)
-* `BOLD`
-* `W_100`
-* `W_200`
-* `W_300`
-* `W_400`
-* `W_500`
-* `W_600`
-* `W_700`
-* `W_800`
-* `W_900`
-
 ### `italic`
 
 `True` to use italic typeface.
+
+### `max_lines`
+
+An optional maximum number of lines for the text to span, wrapping if necessary. If the text exceeds the given number of lines, it will be truncated according to `overflow`.
+
+If this is 1, text will not wrap. Otherwise, text will be wrapped at the edge of the box.
 
 ### `no_wrap`
 
 If `False` (default) the text should break at soft line breaks.
 
 If `True`, the glyphs in the text will be positioned as if there was unlimited horizontal space.
+
+### `overflow`
+
+Property value is `TextOverflow` enum with the following values:
+
+* `FADE` (default)
+* `ELLIPSIS`
+* `CLIP`
+* `VISIBLE`
+
+### `selectable`
+
+`True` if text should be selectable.
+
+### `semantics_label`
+
+An alternative semantics label for this text.
+
+If present, the semantics of this control will contain this value instead of the actual text.
+
+This is useful for replacing abbreviations or shorthands with the full text value:
+
+```python
+ft.Text("$$", semantics_label="Double dollars")
+```
+
+### `size`
+
+Text size in virtual pixels. Default is `14`.
 
 ### `style`
 
@@ -281,29 +273,37 @@ Property value is `TextThemeStyle` enum with one of the following values:
 * `BODY_MEDIUM`
 * `BODY_SMALL`
 
-### `max_lines`
+### `text_align`
 
-An optional maximum number of lines for the text to span, wrapping if necessary. If the text exceeds the given number of lines, it will be truncated according to `overflow`.
+Text horizontal align.
 
-If this is 1, text will not wrap. Otherwise, text will be wrapped at the edge of the box.
+Property value is `TextAlign` enum with the following values:
 
-### `overflow`
+* `LEFT` (default)
+* `RIGHT`
+* `CENTER`
+* `JUSTIFY`
+* `START`
+* `END`
 
-Property value is `TextOverflow` enum with the following values:
+### `value`
 
-* `FADE` (default)
-* `ELLIPSIS`
-* `CLIP`
-* `VISIBLE`
+The text displayed.
 
-### `selectable`
+### `weight`
 
-`True` if text should be selectable.
+Font weight.
 
-### `color`
+Property value is `FontWeight` enum with the following values:
 
-Text foreground color.
-
-### `bgcolor`
-
-Text background color.
+* `NORMAL` (default)
+* `BOLD`
+* `W_100`
+* `W_200`
+* `W_300`
+* `W_400`
+* `W_500`
+* `W_600`
+* `W_700`
+* `W_800`
+* `W_900`

--- a/docs/controls/textbutton.md
+++ b/docs/controls/textbutton.md
@@ -143,9 +143,13 @@ ft.app(target=main)
 
 ## Properties
 
-### `text`
+### `autofocus`
 
-The text displayed on a button.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `content`
+
+A Control representing custom button content.
 
 ### `icon`
 
@@ -159,17 +163,13 @@ Icon color.
 
 See [ElevatedButton.style](elevatedbutton#style) for more information about this property.
 
+### `text`
+
+The text displayed on a button.
+
 ### `tooltip`
 
 The text displayed when hovering the mouse over the button.
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
-### `content`
-
-A Control representing custom button content.
 
 ## Events
 
@@ -177,10 +177,10 @@ A Control representing custom button content.
 
 Fires when a user clicks the button.
 
-### `on_long_press`
-
-Fires when the button is long-pressed.
-
 ### `on_hover`
 
 Fires when a mouse pointer enters or exists the button response area. `data` property of event object contains `true` (string) when cursor enters and `false` when it exits.
+
+### `on_long_press`
+
+Fires when the button is long-pressed.

--- a/docs/controls/textfield.md
+++ b/docs/controls/textfield.md
@@ -192,9 +192,134 @@ ft.app(target=main)
 
 ## Properties
 
-### `value`
+### `autofocus`
 
-Current value of the TextField.
+True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
+
+### `bgcolor`
+
+TextField background color.
+
+### `border`
+
+Border around input - `InputBorder` enum with one of the values: `OUTLINE` (default), `UNDERLINE`, `NONE`.
+
+### `border_color`
+
+Border color. Could be `transparent` to hide the border.
+
+### `border_radius`
+
+See [`Container.border_radius`] property docs for more information about border radius.
+
+### `border_width`
+
+The width of the border in virtual pixels. Default is 1. Set to 0 to completely remove border.
+
+### `can_reveal_password`
+
+Displays a toggle icon button that allows revealing the entered password.
+
+### `capitalization`
+
+Enables automatic on-the-fly capitalization of entered text.
+
+Property value is `TextCapitalization` enum with the following values:
+
+* `NONE` (default) - do not change entered text.
+* `CHARACTERS` - every entered symbol is capitalized.
+* `WORDS` - capitalize the first letter of every word.
+* `SENTENCES` - capitalize the first letter of every sentence.
+
+### `color`
+
+Text color.
+
+### `content_padding`
+
+The padding for the input decoration's container.
+
+See [`Container.padding`](container#padding) for more information about padding and possible values.
+
+### `counter_style`
+
+The style to use for `counter_text`.
+
+### `counter_text`
+
+Optional text to place below the line as a character count.
+
+If null or an empty string and counter isn't specified, then nothing will appear in the counter's location.
+
+### `cursor_color`
+
+The color of TextField cursor.
+
+### `cursor_height`
+
+Sets cursor height.
+
+### `cursor_radius`
+
+Sets cursor radius.
+
+### `cursor_width`
+
+Sets cursor width.
+
+### `error_style`
+
+The style to use for `error_text`.
+
+### `error_text`
+
+Text that appears below the input border.
+
+If non-null, the border's color animates to red and the `helper_text` is not shown.
+
+### `filled`
+
+If `True` the decoration's container is filled with theme fillColor.
+
+### `focused_bgcolor`
+
+Background color of TextField in focused state.
+
+### `focused_border_color`
+
+Border color in focused state.
+
+### `focused_border_width`
+
+Border width in focused state.
+
+### `focused_color`
+
+Text color when TextField is focused.
+
+### `helper_style`
+
+The style to use for `helper_text`.
+
+### `helper_text`
+
+Text that provides context about the input's value, such as how the value will be used.
+
+If non-null, the text is displayed below the input decorator, in the same location as `error_text`. If a non-null `error_text` value is specified then the helper text is not shown.
+
+### `hint_style`
+
+The style to use for `hint_text`.
+
+### `hint_text`
+
+Text that suggests what sort of input the field accepts.
+
+Displayed on top of the input when the it's empty and either (a) `label` is null or (b) the input has the focus.
+
+### `icon`
+
+The name of the icon to show before the input field and outside of the decoration's container.
 
 ### `keyboard_type`
 
@@ -212,63 +337,6 @@ The type of keyboard to use for editing the text. The property value is `Keyboar
 * `STREET_ADDRESS`
 * `NONE`
 
-### `multiline`
-
-`True` if TextField can contain multiple lines of text.
-
-### `min_lines`
-
-The minimum number of lines to occupy when the content spans fewer lines.
-
-This affects the height of the field itself and does not limit the number of lines that can be entered into the field.
-
-Default is `1`.
-
-### `max_lines`
-
-The maximum number of lines to show at one time, wrapping if necessary.
-
-This affects the height of the field itself and does not limit the number of lines that can be entered into the field.
-
-If this is `1` (the default), the text will not wrap, but will scroll horizontally instead.
-
-### `password`
-
-Whether to hide the text being edited. Default is `False`.
-
-### `can_reveal_password`
-
-Displays a toggle icon button that allows revealing the entered password.
-
-### `read_only`
-
-Whether the text can be changed.
-
-When this is set to `True`, the text cannot be modified by any shortcut or keyboard operation. The text is still selectable.
-
-Defaults to `False`.
-
-### `shift_enter`
-
-Changes the behavior of `Enter` button in `multiline` TextField to be chat-like, i.e. new line can be added with `Shift`+`Enter` and pressing just `Enter` fires `on_submit` event.
-
-### `text_align`
-
-How the text should be aligned horizontally.
-
-Property value is `TextAlign` enum with the following values:
-
-* `LEFT` (default)
-* `RIGHT`
-* `CENTER`
-* `JUSTIFY`
-* `START`
-* `END`
-
-### `autofocus`
-
-True if the control will be selected as the initial focus. If there is more than one control on a page with autofocus set, then the first one added to the page will get focus.
-
 ### `label`
 
 Optional text that describes the input field.
@@ -279,130 +347,33 @@ When the input field is empty and unfocused, the label is displayed on top of th
 
 The style to use for `label`.
 
-### `icon`
-
-The name of the icon to show before the input field and outside of the decoration's container.
-
-### `border`
-
-Border around input - `InputBorder` enum with one of the values: `OUTLINE` (default), `UNDERLINE`, `NONE`.
-
-### `content_padding`
-
-The padding for the input decoration's container.
-
-See [`Container.padding`](container#padding) for more information about padding and possible values.
-
-### `filled`
-
-If `True` the decoration's container is filled with theme fillColor.
-
-### `text_size`
-
-Text size in virtual pixels.
-
-### `text_style`
-
-The style to use for the text being edited.
-
-### `color`
-
-Text color.
-
-### `bgcolor`
-
-TextField background color.
-
-### `border_radius`
-
-See [`Container.border_radius`] property docs for more information about border radius.
-
-### `border_width`
-
-The width of the border in virtual pixels. Default is 1. Set to 0 to commpletely remove border.
-
-### `border_color`
-
-Border color. Could be `transparent` to hide the border.
-
-### `focused_color`
-
-Text color when TextField is focused.
-
-### `focused_bgcolor`
-
-Background color of TextField in focused state.
-
-### `focused_border_width`
-
-Border width in focused state.
-
-### `focused_border_color`
-
-Border color in focused state.
-
-### `cursor_color`
-
-The color of TextField cursor.
-
-### `selected_color`
-
-The color of TextField selection.
-
 ### `max_length`
 
 Limits a maximum number of characters that can be entered into TextField.
 
-### `capitalization`
+### `max_lines`
 
-Enables automatic on-the-fly capitalization of entered text.
+The maximum number of lines to show at one time, wrapping if necessary.
 
-Property value is `TextCapitalization` enum with the following values:
+This affects the height of the field itself and does not limit the number of lines that can be entered into the field.
 
-* `NONE` (default) - do not change entered text.
-* `CHARACTERS` - every entered symbol is capitalized.
-* `WORDS` - capitalize the first letter of every word.
-* `SENTENCES` - capitalize the first letter of every sentese.
+If this is `1` (the default), the text will not wrap, but will scroll horizontally instead.
 
-### `hint_text`
+### `min_lines`
 
-Text that suggests what sort of input the field accepts.
+The minimum number of lines to occupy when the content spans fewer lines.
 
-Displayed on top of the input when the it's empty and either (a) `label` is null or (b) the input has the focus.
+This affects the height of the field itself and does not limit the number of lines that can be entered into the field.
 
-### `hint_style`
+Default is `1`.
 
-The style to use for `hint_text`.
+### `multiline`
 
-### `helper_text`
+`True` if TextField can contain multiple lines of text.
 
-Text that provides context about the input's value, such as how the value will be used.
+### `password`
 
-If non-null, the text is displayed below the input decorator, in the same location as `error_text`. If a non-null `error_text` value is specified then the helper text is not shown.
-
-### `helper_style`
-
-The style to use for `helper_text`.
-
-### `counter_text`
-
-Optional text to place below the line as a character count.
-
-If null or an empty string and counter isn't specified, then nothing will appear in the counter's location.
-
-### `counter_style`
-
-The style to use for `counter_text`.
-
-### `error_text`
-
-Text that appears below the input border.
-
-If non-null, the border's color animates to red and the `helper_text` is not shown.
-
-### `error_style`
-
-The style to use for `error_text`.
+Whether to hide the text being edited. Default is `False`.
 
 ### `prefix`
 
@@ -418,13 +389,29 @@ The `prefix` appears after the `prefix_icon`, if both are specified.
 
 An icon that appears before the `prefix` or `prefix_text` and before the editable part of the text field, within the decoration's container.
 
+### `prefix_style`
+
+The style to use for `prefix_text`.
+
 ### `prefix_text`
 
 Optional text `prefix` to place on the line before the input.
 
-### `prefix_style`
+### `read_only`
 
-The style to use for `prefix_text`.
+Whether the text can be changed.
+
+When this is set to `True`, the text cannot be modified by any shortcut or keyboard operation. The text is still selectable.
+
+Defaults to `False`.
+
+### `selected_color`
+
+The color of TextField selection.
+
+### `shift_enter`
+
+Changes the behavior of `Enter` button in `multiline` TextField to be chat-like, i.e. new line can be added with `Shift`+`Enter` and pressing just `Enter` fires `on_submit` event.
 
 ### `suffix`
 
@@ -440,25 +427,38 @@ The `suffix` appears before the `suffix_icon`, if both are specified.
 
 An icon that appears after the editable part of the text field and after the `suffix` or `suffix_text`, within the decoration's container.
 
-### `suffix_text`
-
-Optional text `suffix` to place on the line after the input.
-
 ### `suffix_style`
 
 The style to use for `suffix_text`.
 
-### `cursor_width`
+### `suffix_text`
 
-Sets cursor width.
+Optional text `suffix` to place on the line after the input.
 
-### `cursor_height`
+### `text_align`
 
-Sets cursor height.
+How the text should be aligned horizontally.
 
-### `cursor_radius`
+Property value is `TextAlign` enum with the following values:
 
-Sets cursor radius.
+* `LEFT` (default)
+* `RIGHT`
+* `CENTER`
+* `JUSTIFY`
+* `START`
+* `END`
+
+### `text_size`
+
+Text size in virtual pixels.
+
+### `text_style`
+
+The style to use for the text being edited.
+
+### `value`
+
+Current value of the TextField.
 
 ## Methods
 
@@ -468,18 +468,18 @@ Moves focus to a TextField.
 
 ## Events
 
+### `on_blur`
+
+Fires when the control has lost focus.
+
 ### `on_change`
 
 Fires when the typed input for the TextField has changed.
-
-### `on_submit`
-
-Fires when user presses ENTER while focus is on TextField.
 
 ### `on_focus`
 
 Fires when the control has received focus.
 
-### `on_blur`
+### `on_submit`
 
-Fires when the control has lost focus.
+Fires when user presses ENTER while focus is on TextField.

--- a/docs/controls/tooltip.md
+++ b/docs/controls/tooltip.md
@@ -52,6 +52,18 @@ ft.app(target=main)
 
 ## Properties
 
+### `bgcolor`
+
+Background color of the tooltip.
+
+### `border`
+
+Border around the tooltip.
+
+### `border_radius`
+
+Tooltip's border radius.
+
 ### `content`
 
 The `Control` that should be displayed inside the tooltip.
@@ -66,13 +78,13 @@ When `True` (default) the tooltip should provide acoustic and/or haptic feedback
 
 For example, on Android a tap will produce a clicking sound and a long-press will produce a short vibration, when feedback is enabled.
 
+### `gradient`
+
+Background gradient of the tooltip
+
 ### `height`
 
 The height of the tooltip's content.
-
-### `vertical_offset`
-
-The vertical gap between the widget and the displayed tooltip.
 
 ### `margin`
 
@@ -84,29 +96,19 @@ The amount of space by which to inset the tooltip's content.
 
 On mobile, defaults to 16.0 logical pixels horizontally and 4.0 vertically. On desktop, defaults to 8.0 logical pixels horizontally and 4.0 vertically.
 
-### `bgcolor`
+### `prefer_below`
 
-Background color of the tooltip.
+Whether the tooltip defaults to being displayed below the control.
 
-### `gradient`
-
-Background gradient of the tooltip.
-
-### `border`
-
-Border around the tooltip.
-
-### `border_radius`
-
-Tooltip's border radius.
+Defaults to `True`. If there is insufficient space to display the tooltip in the preferred direction, the tooltip will be displayed in the opposite direction.
 
 ### `shape`
 
 The shape of the tooltip.
 
-### `text_style`
+### `show_duration`
 
-The style to use for the message of the tooltip.
+The length of time, in milliseconds, that the tooltip will be shown after a long press is released or a tap is released or mouse pointer exits the control.
 
 ### `text_align`
 
@@ -121,15 +123,13 @@ Property value is `TextAlign` enum with the following values:
 * `START`
 * `END`
 
-### `prefer_below`
+### `text_style`
 
-Whether the tooltip defaults to being displayed below the control.
+The style to use for the message of the tooltip.
 
-Defaults to `True`. If there is insufficient space to display the tooltip in the preferred direction, the tooltip will be displayed in the opposite direction.
+### `vertical_offset`
 
-### `show_duration`
-
-The length of time, in milliseconds, that the tooltip will be shown after a long press is released or a tap is released or mouse pointer exits the control.
+The vertical gap between the widget and the displayed tooltip.
 
 ### `wait_duration`
 

--- a/docs/controls/verticaldivider.md
+++ b/docs/controls/verticaldivider.md
@@ -62,14 +62,14 @@ ft.app(target=main)
 
 ## Properties
 
-### `width`
+### `color`
 
-The divider's width. The divider itself is always drawn as a vertical line that is centered within the width specified by this value. If this is null, then this defaults to `16.0`.
+The color to use when painting the line.
 
 ### `thickness`
 
 The thickness of the line drawn within the divider. A divider with a thickness of `0.0` is always drawn as a line with a width of exactly one device pixel. If this is null, then this defaults to `0.0`.
 
-### `color`
+### `width`
 
-The color to use when painting the line.
+The divider's width. The divider itself is always drawn as a vertical line that is centered within the width specified by this value. If this is null, then this defaults to `16.0`.

--- a/docs/controls/view.md
+++ b/docs/controls/view.md
@@ -13,9 +13,19 @@ import TabItem from '@theme/TabItem';
 
 ## Properties
 
-### `route`
+### `appbar`
 
-View's route - not currently used by Flet framework, but can be used in a user program to update [`page.route`](/docs/controls/page#route) when a view poped.
+A [`AppBar`](/docs/controls/appbar) control to display at the top of the Page.
+
+### `auto_scroll`
+
+`True` if scrollbar should automatically move its position to the end when children update.
+
+### `bgcolor`
+
+Background color of the Page.
+
+A color value could be a hex value in `#ARGB` format (e.g. `#FFCC0000`), `#RGB` format (e.g. `#CC0000`) or a named color from `flet.colors` module.
 
 ### `controls`
 
@@ -58,21 +68,13 @@ page.update()
 
   </TabItem>
 </Tabs>
+### `route`
 
-### `vertical_alignment`
+View's route - not currently used by Flet framework, but can be used in a user program to update [`page.route`](/docs/controls/page#route) when a view poped.
 
-How the child Controls should be placed vertically.
+### `floating_action_button`
 
-For example, `MainAxisAlignment.START`, the default, places the children at the top of a Page.
-
-Property value is `MainAxisAlignment` enum with the following values:
-
-* `START` (default)
-* `END`
-* `CENTER`
-* `SPACE_BETWEEN`
-* `SPACE_AROUND`
-* `SPACE_EVENLY`
+A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to display on top of Page content.
 
 ### `horizontal_alignment`
 
@@ -87,10 +89,6 @@ Property value is `CrossAxisAlignment` enum with the following values:
 * `END`
 * `STRETCH`
 * `BASELINE`
-
-### `spacing`
-
-Vertical spacing between controls on the Page. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
 
 ### `padding`
 
@@ -109,12 +107,6 @@ page.update()
 
 See [`Container.padding`](container#padding) for more information and possible values.
 
-### `bgcolor`
-
-Background color of the Page.
-
-A color value could be a hex value in `#ARGB` format (e.g. `#FFCC0000`), `#RGB` format (e.g. `#CC0000`) or a named color from `flet.colors` module.
-
 ### `scroll`
 
 Enables a vertical scrolling for the Page to prevent its content overflow.
@@ -129,14 +121,21 @@ Supported values:
 * `ALWAYS` - scrolling is enabled and scroll bar is always shown.
 * `HIDDEN` - scrolling is enabled, but scroll bar is always hidden.
 
-### `auto_scroll`
+### `spacing`
 
-`True` if scrollbar should automatically move its position to the end when children update.
+Vertical spacing between controls on the Page. Default value is 10 virtual pixels. Spacing is applied only when `alignment` is set to `start`, `end` or `center`.
 
-### `appbar`
+### `vertical_alignment`
 
-A [`AppBar`](/docs/controls/appbar) control to display at the top of the Page.
+How the child Controls should be placed vertically.
 
-### `floating_action_button`
+For example, `MainAxisAlignment.START`, the default, places the children at the top of a Page.
 
-A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to display on top of Page content.
+Property value is `MainAxisAlignment` enum with the following values:
+
+* `START` (default)
+* `END`
+* `CENTER`
+* `SPACE_BETWEEN`
+* `SPACE_AROUND`
+* `SPACE_EVENLY`


### PR DESCRIPTION
I went through the pages of all controls, and carefully took time to sort all the properties/events alphabetically. This will help the docs be better organized and hence make searched properties easy to find. Alphabetical sorting is very common in popular documentations.
If this PR is merged, everyone updating (making a PR to) this repo (adding new properties or controls) should also try his/her best to sort alphabetically... for consistency everywhere.
I also made some very minor fixes along the line: updated some code blocks(import flet as ft) and fixed some typos

It might not be an easy task for anyone reviewing my changes, so I propose to check the total number of lines in each of the files I touched/modified. Because I wasn't adding anything new, the total number of lines in each modified file before and after my PR should definitely be equal. (some have a slight diff of one because of removal or addition of the/a last line(whiteline? whitespace?))

You could even try deploying a test website as you used to do, so we could better have a look at the changes.
Let me know how you find my idea, or if there is any issue. :)