### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/controls/view.md
+++ b/docs/controls/view.md
@@ -68,6 +68,7 @@ page.update()
 
   </TabItem>
 </Tabs>
+
 ### `route`
 
 View's route - not currently used by Flet framework, but can be used in a user program to update [`page.route`](/docs/controls/page#route) when a view poped.


### PR DESCRIPTION
The `route` subsection was missing a leading empty line which messed up the markdown formatting. Adding the empty line fixes this.