### PR TITLE
Fixed floating action button link

### DIFF
--- a/docs/controls/filledbutton.md
+++ b/docs/controls/filledbutton.md
@@ -7,7 +7,7 @@ slug: filledbutton
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Filled buttons have the most visual impact after the [FloatingActionButton](floatingactionbutton), and should be used for important, final actions that complete a flow, like **Save**, **Join now**, or **Confirm**. See [Material 3 buttons](https://m3.material.io/components/buttons/overview) for more info.
+Filled buttons have the most visual impact after the [FloatingActionButton](/docs/controls/floatingactionbutton), and should be used for important, final actions that complete a flow, like **Save**, **Join now**, or **Confirm**. See [Material 3 buttons](https://m3.material.io/components/buttons/overview) for more info.
 
 <img src="/img/docs/controls/filled-button/basic-filled-buttons.png" className="screenshot-20" />
 


### PR DESCRIPTION
When clicking on the `FloatingActionButton` link on the floating action button documentation page it would send you to `https://flet.dev/docs/controls/filledbutton/floatingactionbutton` this of course does not exist. 

I have changed the link to `/docs/controls/floatingactionbutton` which should therefore send you to `https://flet.dev/docs/controls/floatingactionbutton` which I presume was the intended destination.