### PR TITLE
Update snackbar.md to include SnackBar.duration

### DIFF
--- a/docs/controls/snackbar.md
+++ b/docs/controls/snackbar.md
@@ -73,7 +73,7 @@ The primary content of the snack bar. Typically a [`Text`](text) control.
 
 ### `duration`
 
-The number of *miliseconds* that the SnackBar stays open for. Defaults to 4000 ([4 seconds](https://api.flutter.dev/flutter/material/SnackBar/duration.html)) when not set.
+The number of *milliseconds* that the SnackBar stays open for. Defaults to 4000 ([4 seconds](https://api.flutter.dev/flutter/material/SnackBar/duration.html)) when not set.
 
 ### `open`
 

--- a/docs/controls/snackbar.md
+++ b/docs/controls/snackbar.md
@@ -71,6 +71,10 @@ SnackBar background [color](/docs/guides/python/colors).
 
 The primary content of the snack bar. Typically a [`Text`](text) control.
 
+### `duration`
+
+The number of *miliseconds* that the SnackBar stays open for. Defaults to 4000 ([4 seconds](https://api.flutter.dev/flutter/material/SnackBar/duration.html)) when not set.
+
 ### `open`
 
 Set to `True` to display a SnackBar. This property is automatically set to `False` once SnackBar is shown.


### PR DESCRIPTION
Added some documentation for `SnackBar.duration`. Clearly mentioned that the duration should be in *milliseconds* so other people will not [open issues about this as I did](https://github.com/flet-dev/flet/issues/1454).