### PR TITLE
Re-Update navigation-and-routing.md

### DIFF
--- a/docs/guides/python/navigation-and-routing.md
+++ b/docs/guides/python/navigation-and-routing.md
@@ -47,7 +47,7 @@ def main(page: ft.Page):
     page.add(ft.Text(f"Initial route: {page.route}"))
 
     def route_change(route):
-        page.add(ft.Text(f"New route: {route}"))
+        page.add(ft.Text(f"New route: {page.route}"))
 
     page.on_route_change = route_change
     page.update()
@@ -68,7 +68,7 @@ def main(page: ft.Page):
     page.add(ft.Text(f"Initial route: {page.route}"))
 
     def route_change(route):
-        page.add(ft.Text(f"New route: {route}"))
+        page.add(ft.Text(f"New route: {page.route}"))
 
     def go_store(e):
         page.route = "/store"

--- a/docs/guides/python/navigation-and-routing.md
+++ b/docs/guides/python/navigation-and-routing.md
@@ -46,8 +46,8 @@ import flet as ft
 def main(page: ft.Page):
     page.add(ft.Text(f"Initial route: {page.route}"))
 
-    def route_change(route):
-        page.add(ft.Text(f"New route: {page.route}"))
+    def route_change(e: ft.RouteChangeEvent):
+        page.add(ft.Text(f"New route: {e.route}"))
 
     page.on_route_change = route_change
     page.update()
@@ -67,8 +67,8 @@ import flet as ft
 def main(page: ft.Page):
     page.add(ft.Text(f"Initial route: {page.route}"))
 
-    def route_change(route):
-        page.add(ft.Text(f"New route: {page.route}"))
+    def route_change(e: ft.RouteChangeEvent):
+        page.add(ft.Text(f"New route: {e.route}"))
 
     def go_store(e):
         page.route = "/store"


### PR DESCRIPTION
-The route variable `{route}` should be replaced with `{page.route}`.  
-Also the URL `localhost:8000/#/test` for instance, only redirects back to `/`. 
   Instead, the URL used should just be `localhost:8000/test`.