### PR TITLE
Realtime Chat app tutorial - fixing sample code

### DIFF
--- a/docs/tutorials/python-realtime-chat.md
+++ b/docs/tutorials/python-realtime-chat.md
@@ -88,7 +88,7 @@ def main(page: ft.Page):
         chat, ft.Row(controls=[new_message, ft.ElevatedButton("Send", on_click=send_click)])
     )
 
-ft.app("chat", target=main, view=ft.WEB_BROWSER)
+ft.app(target=main, view=ft.WEB_BROWSER)
 ```
 
 When user clicks on the "Send" button, it triggers `on_click` event which calls `send_click` method. `send_click` then adds new `Text` control to the list of Column `controls` and clears `new_message` TextField value.


### PR DESCRIPTION
## Issue
<img width="612" alt="image" src="https://github.com/flet-dev/website/assets/35943761/3f04e81e-fed1-423d-888c-0f0d9980c9ea">

Copy-pasting the initial sample code results in error as seen in screenshot above.

Problematic line is:
```python
ft.app("chat", target=main, view=ft.WEB_BROWSER)
```

Which gives error:
> ft.app("chat", target=main, view=ft.WEB_BROWSER)
> TypeError: app() got multiple values for argument 'target'


## Proposed Fix
Delete `"chat"` from problematic line, resulting in:
```python
ft.app(target=main, view=ft.WEB_BROWSER)
```

