### PR TITLE
Corrected TextThemeStyle in documentation

### DIFF
--- a/docs/controls/text.md
+++ b/docs/controls/text.md
@@ -86,7 +86,7 @@ def main(page: ft.Page):
         ft.Text("Display Small", style=ft.TextThemeStyle.DISPLAY_SMALL),
         ft.Text("Headline Large", style=ft.TextThemeStyle.HEADLINE_LARGE),
         ft.Text("Headline Medium", style=ft.TextThemeStyle.HEADLINE_MEDIUM),
-        ft.Text("Headline Small", style=ft.TextThemeStyle.HEADLINE_MEDIUM),
+        ft.Text("Headline Small", style=ft.TextThemeStyle.HEADLINE_SMALL),
         ft.Text("Title Large", style=ft.TextThemeStyle.TITLE_LARGE),
         ft.Text("Title Medium", style=ft.TextThemeStyle.TITLE_MEDIUM),
         ft.Text("Title Small", style=ft.TextThemeStyle.TITLE_SMALL),


### PR DESCRIPTION
This commit corrects the TextThemeStyle in the Flet documentation. The style for "Headline Small" was incorrectly documented as ft.TextThemeStyle.HEADLINE_MEDIUM. This has been corrected to ft.TextThemeStyle.HEADLINE_SMALL.