### PR TITLE
Update the Navigation and Routing blog page.

### DIFF
--- a/blog/2022-07-23-navigation-and-routing.md
+++ b/blog/2022-07-23-navigation-and-routing.md
@@ -163,7 +163,7 @@ Notice the usage of [`page.on_view_pop`](/docs/controls/page#on_view_pop) event 
 
 ## Route templates
 
-Flet offers [`TemplateRoute`](https://github.com/flet-dev/flet/blob/main/sdk/python/flet/template_route.py) - an utility class based on [repath](https://github.com/nickcoutsos/python-repath) library which allows matching ExpressJS-like routes and parsing their parameters, for example `/account/:account_id/orders/:order_id`.
+Flet offers [`TemplateRoute`](https://github.com/flet-dev/flet/blob/main/sdk/python/packages/flet-core/src/flet_core/template_route.py) - an utility class based on [repath](https://github.com/nickcoutsos/python-repath) library which allows matching ExpressJS-like routes and parsing their parameters, for example `/account/:account_id/orders/:order_id`.
 
 `TemplateRoute` plays great with route change event:
 


### PR DESCRIPTION
The `template_route.py` file referenced in this page has been moved to [another location](https://github.com/flet-dev/flet/blob/main/sdk/python/packages/flet-core/src/flet_core/template_route.py), this PR fixes that small issue.