### PR TITLE
fix: instructions on VS toolchain error for desktop

### DIFF
--- a/docs/guides/python/packaging-app-for-distribution.md
+++ b/docs/guides/python/packaging-app-for-distribution.md
@@ -58,8 +58,17 @@ Please enable Developer Mode in your system settings. Run
   start ms-settings:developers
 to open settings.
 ```
+[Follow this SO answer](https://stackoverflow.com/a/70994092/1435891) for the instructions on how to enable developer mode in Windows 11.  
 
-[Follow this SO answer](https://stackoverflow.com/a/70994092/1435891) for the instructions on how to enable developer mode in Windows 11.
+#### Visual Studio
+
+```
+Unable to find suitable Visual Studio toolchain. Please run `flutter
+doctor` for more details.
+```
+
+[Follow this medium article](https://medium.com/@teamcode20233/a-guide-to-install-desktop-development-with-c-workload-542bb92cfe90) for the instructions on downloading & installing correct Visual Studio components for desktop development.
+
 
 ### Build platform matrix
 


### PR DESCRIPTION
added instructions for this error
```
Unable to find suitable Visual Studio toolchain. Please run `flutter
doctor` for more details.
```
[link to the instructions](https://medium.com/@teamcode20233/a-guide-to-install-desktop-development-with-c-workload-542bb92cfe90) - medium article on Visual Studio for Desktop development.

UI screenshot for this pr:
![image](https://github.com/flet-dev/website/assets/65155920/2fc01ff6-c50a-4742-b748-9dd50f4185bb)


