### PR TITLE
SegmentedButtonDoc parameter name Updated

### DIFF
--- a/docs/controls/segmentedbutton.md
+++ b/docs/controls/segmentedbutton.md
@@ -65,7 +65,7 @@ ft.app(target=main)
 
 ## `SegmentedButton` Properties
 
-### `empty_selection_allowed`
+### `allow_empty_selection`
 
 A boolean value that indicates if having no selected segments is allowed. 
 
@@ -73,7 +73,7 @@ If `True`, then it is acceptable for none of the segments to be selected and als
 
 If `False` (the default), there must be at least one segment selected. If the user taps on the only selected segment it will not be deselected, and `on_change` will not be called.
 
-### `multi_selection_enabled`
+### `allow_multiple_selection`
 
 A boolean value that indicates if multiple segments can be selected at one time.
 


### PR DESCRIPTION
Renamed the following parameters with its actual name from SegmentedButton Class
1. empty_selection_allowed
2. multi_selection_enabled