### PR TITLE
Update command for `temurin8` brew install

### DIFF
--- a/docs/guides/python/packaging-app-for-distribution.md
+++ b/docs/guides/python/packaging-app-for-distribution.md
@@ -479,6 +479,7 @@ On macOS Android SDK will be located at `$HOME/Library/Android/sdk`.
 Install Temurin8 to get JRE 1.8 required by `sdkmanager` tool:
 
 ```bash
+brew tap homebrew/cask-versions
 brew install --cask temurin8
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home
 ```


### PR DESCRIPTION
To install a specific java version, we have to install the `cask-versions` for temurin.