### PR TITLE
Updated overflow param in Text widget to use ft.TextOverflow

### DIFF
--- a/docs/controls/text.md
+++ b/docs/controls/text.md
@@ -50,7 +50,7 @@ def main(page: ft.Page):
         ft.Text(
             "Proin rutrum, purus sit amet elementum volutpat, nunc lacus vulputate orci, cursus ultrices neque dui quis purus. Ut ultricies purus nec nibh bibendum, eget vestibulum metus varius. Duis convallis maximus justo, eu rutrum libero maximus id. Donec ullamcorper arcu in sapien molestie, non pellentesque tellus pellentesque. Nulla nec tristique ex. Maecenas euismod nisl enim, a convallis arcu laoreet at. Ut at tortor finibus, rutrum massa sit amet, pulvinar velit. Phasellus diam lorem, viverra vitae leo vitae, consequat suscipit lorem.",
             max_lines=1,
-            overflow="ellipsis",
+            overflow=ft.TextOverflow.ELLIPSIS,
         ),
         ft.Text("Limit long text to 2 lines and fading", theme_style=ft.TextThemeStyle.HEADLINE_SMALL),
         ft.Text(


### PR DESCRIPTION
overflow in Text widget has 'ellipsis' as a string, updated `overflow` param to use `ft.TextOverflow.ELLIPSIS` as per param type.