### PR TITLE
Fixed typos with codespell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ yarn-error.log*
 
 # Yarn
 /.yarn
+
+.venv/

--- a/blog/2022-08-04-gradients-button-textfield-styles.md
+++ b/blog/2022-08-04-gradients-button-textfield-styles.md
@@ -128,7 +128,7 @@ Check [`SweepGradient`](/docs/reference/types/sweepgradient) docs for more infor
 ## Buttons styling
 
 This Flet release introduces `style` property to all button controls which is an instance of `ButtonStyle` class.
-`ButtonStyle` allows controling all visual aspects of a button, such as shape, foreground, background and shadow colors, content padding, border width and radius!
+`ButtonStyle` allows controlling all visual aspects of a button, such as shape, foreground, background and shadow colors, content padding, border width and radius!
 
 Moreover, each individual style attribute could be configured for a different "Material states" of a button, such as "hovered", "focused", "disabled" and others. For example, you can configure a different shape, background color for a hovered state and configure fallback values for all other states.
 

--- a/blog/2022-10-24-matplotlib-and-plotly-charts.md
+++ b/blog/2022-10-24-matplotlib-and-plotly-charts.md
@@ -40,7 +40,7 @@ Learn Python libraries by examples:
 * [Matplotlib gallery](https://matplotlib.org/stable/gallery/index.html)
 * [Plotly gallery](https://plotly.com/python/)
 
-In the future releases, we may add an interactive "toolbar" for Matplotlib charts by implementing a custom [backend](https://matplotlib.org/stable/users/explain/backends.html). Or maybe it's a great excersize for Flet users? 😉
+In the future releases, we may add an interactive "toolbar" for Matplotlib charts by implementing a custom [backend](https://matplotlib.org/stable/users/explain/backends.html). Or maybe it's a great exercise for Flet users? 😉
 
 Also, when it's time for Flet to support other languages we would need to re-visit charting to make it language-agnostic as the current charting implementation relies on Python libraries.
 

--- a/blog/2022-11-13-responsive-row-and-mobile-controls.md
+++ b/blog/2022-11-13-responsive-row-and-mobile-controls.md
@@ -16,7 +16,7 @@ We just released [Flet 0.1.65](https://pypi.org/project/flet/0.1.65/) which is a
 
 `ResponsiveRow` allows aligning child controls to virtual columns. By default, a virtual grid has 12 columns, but that can be customized with `ResponsiveRow.columns` property.
 
-Similar to `expand` property every control now has `col` property which allows specifying how many columns a control should span. For examle, to make a layout consisting of two columns spanning 6 virtual columns each:
+Similar to `expand` property every control now has `col` property which allows specifying how many columns a control should span. For example, to make a layout consisting of two columns spanning 6 virtual columns each:
 
 ```python
 import flet as ft

--- a/blog/2022-12-08-flet-mobile-update.md
+++ b/blog/2022-12-08-flet-mobile-update.md
@@ -63,7 +63,7 @@ Using of async libraries from a sync code is [possible](https://github.com/flet-
 
 Async/await model is a state machine switching between tasks in a single thread. By going async Flet will able to utilize [streams](https://docs.python.org/3/library/asyncio-stream.html) for socket server and use async [WebSockets library](https://pypi.org/project/websockets/) library. It will be possible to use both sync and async event handlers in a single Flet app without any compromises or hacks.
 
-Even more exciting, async Flet will be able to run entirely in the browser within [Pyodide](https://pyodide.org/) - Python distribution based on WebAssembly (WASM). WebAssembly doesn't have multi-threading support yet, so running in a single thread is a must. Just imagine, Flet web app with a trully offline Flet PWA that does not require a web server to run a Python code!
+Even more exciting, async Flet will be able to run entirely in the browser within [Pyodide](https://pyodide.org/) - Python distribution based on WebAssembly (WASM). WebAssembly doesn't have multi-threading support yet, so running in a single thread is a must. Just imagine, Flet web app with a truly offline Flet PWA that does not require a web server to run a Python code!
 
 ## Development plan
 

--- a/blog/2023-12-30-packaging-apps-for-distribution.md
+++ b/blog/2023-12-30-packaging-apps-for-distribution.md
@@ -13,7 +13,7 @@ to Flet project whether it's spreading a word, submitting pull request, joining 
 
 With your fantastic support we achieved a lot in year 2023:
 
-* 70+ controls (special thanks to [@ndonkoHenri](https://github.com/ndonkoHenri) for his tremendous contibution).
+* 70+ controls (special thanks to [@ndonkoHenri](https://github.com/ndonkoHenri) for his tremendous contribution).
 * 7,700 stars on GitHub.
 * 2,150 users with community moderators (thank you guys!) on Discord.
 * Flet integration with Pyodide for pure client-side Python apps - no other frameworks provide a better UI for Pyodide!

--- a/blog/2024-03-06-flet-fastapi-and-async-api-improvements.md
+++ b/blog/2024-03-06-flet-fastapi-and-async-api-improvements.md
@@ -19,7 +19,7 @@ Here's what's new in Flet 0.21.0:
 From very beginning of Flet life to serve web apps there was a built-in web server written in Go
 and called "Fletd". It's being started on the background when you run your app with `flet run --web`.
 Fletd was part of Flet Python wheel contributing a few megabytes to its size.
-Additionally, Python app was using WebSockets to talk to Fletd web server which was adding sometimes noticable overhead.
+Additionally, Python app was using WebSockets to talk to Fletd web server which was adding sometimes noticeable overhead.
 
 Then, in [Flet 0.10.0](/blog/flet-for-fastapi) we have added FastAPI support to build "serious" web apps using AsyncIO API.
 

--- a/blog/2024-05-01-flet-packaging-update.md
+++ b/blog/2024-05-01-flet-packaging-update.md
@@ -83,7 +83,7 @@ fastapi (0.110.3)
 
 ## Current approach
 
-We released the first version of packaging [4 months ago](/blog/packaging-apps-for-distribution) and since then, we have realized that the initial approach has multple flaws and should be improved.
+We released the first version of packaging [4 months ago](/blog/packaging-apps-for-distribution) and since then, we have realized that the initial approach has multiple flaws and should be improved.
 
 When you run `flet build apk` with the current Flet version it downloads Python runtime with standard library both pre-built for Android (or iOS if ran with `flet build ipa`).
 

--- a/docs/controls/column.md
+++ b/docs/controls/column.md
@@ -247,7 +247,7 @@ ft.app(target=main)
 
 ### Infinite scroll list
 
-The following example demonstrates adding of list items on-the-fly, as user scroll to the bottom, creating the illusion of inifinite list:
+The following example demonstrates adding of list items on-the-fly, as user scroll to the bottom, creating the illusion of infinite list:
 
 ```python
 import threading
@@ -425,7 +425,7 @@ When set to `True` the Column will put child controls into additional columns (r
 
 Moves scroll position to either absolute `offset`, relative `delta` or jump to the control with specified `key`.
 
-`offset` is an abosulte value between minimum and maximum extents of a scrollable control, for example:
+`offset` is an absolute value between minimum and maximum extents of a scrollable control, for example:
 
 ```python
 products.scroll_to(offset=100, duration=1000)

--- a/docs/controls/navigationbar.md
+++ b/docs/controls/navigationbar.md
@@ -87,7 +87,7 @@ Property value is `NavigationBarLabelBehavior` enum with the following values:
 
 ### `overlay_color`
 
-The hightlight [color](/docs/reference/colors) of the `NavigationDestination` in various [`MaterialState`](/docs/reference/types/materialstate) states. The
+The highlight [color](/docs/reference/colors) of the `NavigationDestination` in various [`MaterialState`](/docs/reference/types/materialstate) states. The
 following [`MaterialState`](/docs/reference/types/materialstate) values are supported: `PRESSED`, `HOVERED` and `FOCUSED`.
 
 ### `selected_index`

--- a/docs/controls/tabs.md
+++ b/docs/controls/tabs.md
@@ -58,7 +58,7 @@ ft.app(target=main)
 
 ### `animation_duration`
 
-Duration of animation in milliseconds of swtiching between tabs. Default is `50`.
+Duration of animation in milliseconds of switching between tabs. Default is `50`.
 
 ### `clip_behavior`
 

--- a/docs/cookbook/authentication.md
+++ b/docs/cookbook/authentication.md
@@ -100,7 +100,7 @@ ft.app(target=main, port=8550, view=ft.WEB_BROWSER)
 
 :::caution
 Notice, we are fetching OAuth app client ID and client secret from an environment variables.
-Do not embed any secrets into source code to avoid accidential exposure to a public!
+Do not embed any secrets into source code to avoid accidental exposure to a public!
 :::
 
 Before running the app set the secret environment variables in a command line:
@@ -310,7 +310,7 @@ ejt = encrypt(jt, secret_key)
 
 :::caution
 Notice, we are fetching a secret key (aka passphrase, password, etc.) from an environment variable.
-Do not embed any secrets into source code to avoid accidential exposure to a public!
+Do not embed any secrets into source code to avoid accidental exposure to a public!
 :::
 
 Before running the app set the secret in a command line:

--- a/docs/cookbook/client-storage.md
+++ b/docs/cookbook/client-storage.md
@@ -27,7 +27,7 @@ page.client_storage.set("favorite_colors", ["red", "green", "blue"])
 ```
 
 :::note
-Each Flutter application using `shared_preferences` plugin has its own set of preferences. As the same Flet client (which is a Flutter app) is used to run UI for muliple Flet apps any values stored in one Flet application are visible/available to another Flet app running by the same user.
+Each Flutter application using `shared_preferences` plugin has its own set of preferences. As the same Flet client (which is a Flutter app) is used to run UI for multiple Flet apps any values stored in one Flet application are visible/available to another Flet app running by the same user.
 
 To distinguish one application settings from another it is recommended to use some unique prefix for all storage keys, for example `{company}.{product}.`. For example to store auth token in one app you could use `acme.one_app.auth_token` key and in another app use `acme.second_app.auth_token`.
 :::

--- a/docs/cookbook/encrypting-sensitive-data.md
+++ b/docs/cookbook/encrypting-sensitive-data.md
@@ -12,7 +12,7 @@ Flet includes utility methods to encrypt and decrypt sensitive text data using s
 Encryption secret key (aka password, or passphrase) is an arbitrary password-like string configured by a user and used for encrypting and decrypting data. Crypto algorithm uses secret key to "derive" encryption key (32 bytes).
 
 :::danger
-Do not embed any secrets into the source code to avoid accidential exposure to the public!
+Do not embed any secrets into the source code to avoid accidental exposure to the public!
 :::
 
 You can provide a secret to your app via environment variable:

--- a/docs/cookbook/large-lists.md
+++ b/docs/cookbook/large-lists.md
@@ -93,7 +93,7 @@ Try scrolling and resizing the browser window - everything works, but very laggy
 :::note
 At the start of the program we are setting the value of `FLET_WS_MAX_MESSAGE_SIZE` environment variable to `8000000` - this is the maximum size of WebSocket message in bytes that can be received by Flet Server rendering the page. Default size is 1 MB, but the size of JSON message describing 5,000 container controls would exceed 1 MB, so we are increasing allowed size to 8 MB.
 
-Squeezing large messages through WebSocket channel is, generally, not a good idea, so use [batched updates](#batch-updates) aproach to control channel load.
+Squeezing large messages through WebSocket channel is, generally, not a good idea, so use [batched updates](#batch-updates) approach to control channel load.
 :::
 
 GridView, similar to ListView, is very effective to render a lot of children. Let's implement the example above using GridView:

--- a/docs/getting-started/adaptive-apps.md
+++ b/docs/getting-started/adaptive-apps.md
@@ -89,7 +89,7 @@ ft.Checkbox(adaptive=True, value=True, label="Adaptive Checkbox")
 Flet checks the value of [`page.platform`](/docs/controls/page#platform) property and if it is `ft.PagePlatform.IOS` or `ft.PagePlatform.MACOS`, Cupertino control will be created; in all other cases Material control will be created. 
 
 :::note
-[`adaptive`](/docs/controls#adaptive) property can be set for an individual control or a container control such as `Row`, `Column` or any other control that has `content` or `controls` property. If container control is adaptive, all its child controls will be adaptive, unless `adaptive` property is explicitely set to `False` for a child control.
+[`adaptive`](/docs/controls#adaptive) property can be set for an individual control or a container control such as `Row`, `Column` or any other control that has `content` or `controls` property. If container control is adaptive, all its child controls will be adaptive, unless `adaptive` property is explicitly set to `False` for a child control.
 :::
 
 Below is the list of adaptive Material controls and their matching Cupertino controls:

--- a/docs/getting-started/displaying-data.md
+++ b/docs/getting-started/displaying-data.md
@@ -5,7 +5,7 @@ sidebar_label: Displaying data
 
 ## Text
 
-`Text` control is used to output textual data. Its main properties are `value` and `size`, but it also has a number of formatting properties to control its appearence. For example:
+`Text` control is used to output textual data. Its main properties are `value` and `size`, but it also has a number of formatting properties to control its appearance. For example:
 
 ```python
 t = ft.Text(

--- a/docs/getting-started/flet-controls.md
+++ b/docs/getting-started/flet-controls.md
@@ -96,7 +96,7 @@ def main(page):
         new_task.focus()
         new_task.update()
 
-    new_task = ft.TextField(hint_text="Whats needs to be done?", width=300)
+    new_task = ft.TextField(hint_text="What's needs to be done?", width=300)
     page.add(ft.Row([new_task, ft.ElevatedButton("Add", on_click=add_clicked)]))
 
 ft.app(target=main)

--- a/docs/publish/index.md
+++ b/docs/publish/index.md
@@ -52,7 +52,7 @@ If only `icon.png` (or other supported format such as `.bmp`, `.jpg`, `.webp`) i
 :::caution No pip freeze
 
 Do not use `pip freeze > requirements.txt` command to create `requirements.txt` for the app that
-will be runnin on mobile. As you run `pip freeze` command on a desktop `requirements.txt` will have
+will be running on mobile. As you run `pip freeze` command on a desktop `requirements.txt` will have
 dependencies that are not intended to work on a mobile device, such as `watchdog`.
 
 Hand-pick `requirements.txt` to have only direct dependencies required by your app, plus `flet`. 
@@ -163,7 +163,7 @@ By default, `flet build` command assumes `main.py` as the entry point of your Fl
 
 ## Versioning
 
-You can provide a version information for built executable or package with `--build-number` and `--build-version` arguments. This is the information that is used to destinguish one build/release from another in App Store and Google Play and is shown to the user in about dialogs.
+You can provide a version information for built executable or package with `--build-number` and `--build-version` arguments. This is the information that is used to distinguish one build/release from another in App Store and Google Play and is shown to the user in about dialogs.
 
 `--build-number` - an integer number (default is `1`), an identifier used as an internal version number.
 Each build must have a unique identifier to differentiate it from previous builds.

--- a/docs/publish/web/dynamic-website/index.md
+++ b/docs/publish/web/dynamic-website/index.md
@@ -42,7 +42,7 @@ ft.app(main)
 In the example a click on one button is handled by a "blocking" handler while a click
 on second button calls asynchronous handler. The first handler is run in a `threading.Thread` while second handler is run as `asyncio.Task`.
 
-In web apps, using threads is one of the considerations for app scalability as threads is a finite resource. Usually, a thread pool is used and it could become a bottleneck with a growing numner of users.
+In web apps, using threads is one of the considerations for app scalability as threads is a finite resource. Usually, a thread pool is used and it could become a bottleneck with a growing number of users.
 
 Anyway, if your app is mostly doing I/O (database, web API) and/or you are able to use async-ready libraries we recommend implementing async handlers.
 

--- a/docs/tutorials/python-realtime-chat.md
+++ b/docs/tutorials/python-realtime-chat.md
@@ -11,7 +11,7 @@ In this tutorial you will learn how to:
 * [Add page controls and handle events](#adding-page-controls-and-handling-events)
 * [Broadcast messages using built-in PubSub library](#broadcasting-chat-messages)
 * [Use AlertDialog control for accepting user name](#user-name-dialog)
-* [Enhance user interface with re-usable controls](#enhancing-user-interface)
+* [Enhance user interface with reusable controls](#enhancing-user-interface)
 * [Deploy the app as a web app](#deploying-the-app)
 
 The complete application will look like this:
@@ -112,7 +112,7 @@ First, we need subscribe the user to receive broadcast messages:
     page.pubsub.subscribe(on_message)
 ```
 
-`pubsub.subsribe()` method will add current app session to the list of subscribers. It accepts `handler` as an argument, that will later be called at the moment a publisher calls `pubsub.send_all()` method.
+`pubsub.subscribe()` method will add current app session to the list of subscribers. It accepts `handler` as an argument, that will later be called at the moment a publisher calls `pubsub.send_all()` method.
 
 In the `handler` we will be adding new message (`Text`) to the list of chat `controls`:
 ```python
@@ -239,7 +239,7 @@ We used [page session storage](/docs/cookbook/session-storage) to store user_nam
 User name dialog will close as soon as we set its `open` property to `False` and call `update()` method. 
 :::
 
-Finally, let's update `send_click` method to use `user_name` that we previosly saved using `page.session`:
+Finally, let's update `send_click` method to use `user_name` that we previously saved using `page.session`:
 
 ```python
 def send_click(e):
@@ -258,7 +258,7 @@ Chat app that you have created in the previous step already serves its purpose o
 
 Before moving on to [deploying your app](#deploying-the-app), we suggest adding some extra features to it that will improve user experience and make the app look more professional.
 
-### Re-usable user controls
+### Reusable user controls
 
 You may want to show messages in a different format, like this:
 <img src="/img/docs/chat-tutorial/chat-layout-chatmessage.svg" className="screenshot-70" />
@@ -336,7 +336,7 @@ Instances of `ChatMessage` will be created instead of plain `Text` chat messages
 Other improvements suggested with the new layout are:
 
 * [`ListView`](/docs/controls/listview) instead of `Column` for displaying messages, to be able to scroll through the messages later
-* `Container` for displaing border around `ListView`
+* `Container` for displaying border around `ListView`
 * [`IconButton`](/docs/controls/iconbutton) instead of `ElevatedButton` to send messages
 * Use of [`expand`](/docs/controls#expand) property for controls to fill available space
 

--- a/docs/tutorials/python-solitaire.md
+++ b/docs/tutorials/python-solitaire.md
@@ -658,7 +658,7 @@ def create_card_deck(self):
         for rank in ranks:
             self.cards.append(Card(solitaire=self, suite=suite, rank=rank))
 ```
-The card deck is ready to be dealed, and now we need to create the layout for it.
+The card deck is ready to be dealt, and now we need to create the layout for it.
 
 ### Create slots
 

--- a/docs/tutorials/python-todo.md
+++ b/docs/tutorials/python-todo.md
@@ -65,7 +65,7 @@ def main(page: ft.Page):
         new_task.value = ""
         page.update()
 
-    new_task = ft.TextField(hint_text="Whats needs to be done?")
+    new_task = ft.TextField(hint_text="What's needs to be done?")
 
     page.add(new_task, ft.FloatingActionButton(icon=ft.icons.ADD, on_click=add_clicked))
 
@@ -96,7 +96,7 @@ def main(page: ft.Page):
         new_task.value = ""
         view.update()
 
-    new_task = ft.TextField(hint_text="Whats needs to be done?", expand=True)
+    new_task = ft.TextField(hint_text="What's needs to be done?", expand=True)
     tasks_view = ft.Column()
     view=ft.Column(
         width=600,
@@ -132,7 +132,7 @@ import flet as ft
 
 class TodoApp(ft.UserControl):
     def build(self):
-        self.new_task = ft.TextField(hint_text="Whats needs to be done?", expand=True)
+        self.new_task = ft.TextField(hint_text="What's needs to be done?", expand=True)
         self.tasks = ft.Column()
 
         # application's root control (i.e. "view") containing all other controls
@@ -264,7 +264,7 @@ Additionally, we changed `TodoApp` class to create and hold `Task` instances whe
 ```python
 class TodoApp(ft.UserControl):
     def build(self):
-        self.new_task = ft.TextField(hint_text="Whats needs to be done?", expand=True)
+        self.new_task = ft.TextField(hint_text="What's needs to be done?", expand=True)
         self.tasks = ft.Column()
         # ...
 
@@ -319,7 +319,7 @@ Copy the entire code for this step from [here](https://github.com/flet-dev/examp
 class TodoApp(ft.UserControl):
     def __init__(self):
         self.tasks = []
-        self.new_task = ft.TextField(hint_text="Whats needs to be done?", expand=True)
+        self.new_task = ft.TextField(hint_text="What's needs to be done?", expand=True)
         self.tasks = ft.Column()
 
         self.filter = ft.Tabs(


### PR DESCRIPTION
```
python -v venv .venv
source .venv/bin/activate
pip install codespell
codespell --ignore-words-list=rouge --skip="*.css,*.js,*.svg" --write-changes
```