### PR TITLE
build() instead of __init__() in TodoApp class examples

### DIFF
--- a/docs/tutorials/python-todo.md
+++ b/docs/tutorials/python-todo.md
@@ -317,7 +317,7 @@ Copy the entire code for this step from [here](https://github.com/flet-dev/examp
 # ...
 
 class TodoApp(ft.UserControl):
-    def __init__(self):
+    def build(self):
         self.tasks = []
         self.new_task = ft.TextField(hint_text="What's needs to be done?", expand=True)
         self.tasks = ft.Column()
@@ -409,7 +409,7 @@ Copy the entire code for this step from [here](https://github.com/flet-dev/examp
 
 ```python
 class TodoApp():
-    def __init__(self):
+    def build(self):
         # ...
 
         self.items_left = ft.Text("0 items left")


### PR DESCRIPTION
I got the next issue while following the tutorial: ```TypeError: __init__() should return None, not 'Column'```. It seems the TodoApp() class have `build()`method instead of the `__init__()`

BTW, thanks guys for your awesome work, I'm exploring this framework to prototype a mobile app and it seems it's a great option for those who are not very familiar with Dart stuff