### PR TITLE
Update macos.md

### DIFF
--- a/docs/publish/macos.md
+++ b/docs/publish/macos.md
@@ -12,3 +12,19 @@ The command can be run on macOS only.
 ## `flet build macos`
 
 Creates a macOS application bundle from your Flet app.
+
+### Specify output directory
+
+If you specify the build directory then the directory acts like a cache, speeding up subsequent builds.
+
+```bash
+flet build -o ./build macos
+```
+
+## Debugging the build process
+
+You can use both 
+- `flet build -v` for verbose logging or
+- `flet build -vv` for the highest level of verbose logging.
+
+If something is not working in your build process then you may need the highest verbosity of logging.


### PR DESCRIPTION
Document both the -v and -vv build logging commands.

This would have saved my team a day or two if this were in the documentation