### PR TITLE
Add types and default values references to `AlertDialog`, `AnimatedSwitcher`, `AppBar`, `Audio`, `AudioRecorder`, `AutoComplete`, `AutoFillGroup`, `Badge`, `View`, `WebView` and `WindowDragArea` controls

### DIFF
--- a/docs/controls/alertdialog.md
+++ b/docs/controls/alertdialog.md
@@ -95,7 +95,7 @@ Typically used to provide padding to the button bar between the button bar and t
 
 If are no actions, then no padding will be included. The padding around the button bar defaults to zero.
 
-The value of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `adaptive`
 
@@ -122,7 +122,7 @@ Value is of type [`ClipBehavior`](/docs/reference/types/clipbehavior) and defaul
 
 The (optional) content of the dialog is displayed in the center of the dialog in a lighter font. Typically this is a [`Column`](/docs/controls/column) that contains the dialog's [`Text`](/docs/controls/text) message.
 
-Value is of type [`Control`].
+Value is of type `Control`.
 
 ### `content_padding`
 
@@ -130,7 +130,7 @@ Padding around the content.
 
 If there is no content, no padding will be provided. Otherwise, padding of 20 pixels is provided above the content to separate the content from the title, and padding of 24 pixels is provided on the left, right, and bottom to separate the content from the other edges of the dialog.
 
-The value of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `elevation`
 
@@ -205,7 +205,7 @@ Padding around the title.
 
 If there is no title, no padding will be provided. Otherwise, this padding is used.
 
-The value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 Defaults to providing `24` pixels on the top, left, and right of the title. If the `content` is not `None`, then no
 bottom padding is provided (but see [`content_padding`](#content_padding)).

--- a/docs/controls/alertdialog.md
+++ b/docs/controls/alertdialog.md
@@ -79,7 +79,7 @@ Typically this is a list of [`TextButton`](/docs/controls/textbutton) controls.
 
 The padding that surrounds each button in `actions`.
 
-Value is of type `PaddingValue`.
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `actions_alignment`
 
@@ -120,7 +120,9 @@ Value is of type [`ClipBehavior`](/docs/reference/types/clipbehavior) and defaul
 
 ### `content`
 
-The (optional) content (of type `Control`) of the dialog is displayed in the center of the dialog in a lighter font. Typically this is a [`Column`](/docs/controls/column) that contains the dialog's [`Text`](/docs/controls/text) message.
+The (optional) content of the dialog is displayed in the center of the dialog in a lighter font. Typically this is a [`Column`](/docs/controls/column) that contains the dialog's [`Text`](/docs/controls/text) message.
+
+Value is of type [`Control`].
 
 ### `content_padding`
 
@@ -144,7 +146,7 @@ A control that is displayed at the top of the dialog. Typically a [`Icon`](/docs
 
 Padding around the `icon`.
 
-Value is of type `PaddingValue`.
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `inset_padding`
 
@@ -173,7 +175,7 @@ The semantic label of the dialog used by accessibility frameworks to announce sc
 
 In iOS, if this label is not provided, a semantic label will be inferred from the `title` if it is not null.
 
-Value is of type `str` or `None`
+Value is of type `str`.
 
 ### `shadow_color`
 

--- a/docs/controls/alertdialog.md
+++ b/docs/controls/alertdialog.md
@@ -152,7 +152,7 @@ Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 Padding around the Dialog itself.
 
-The value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 Defaults to `padding.symmetric(vertical=40, horizontal=24)` - 40 pixels horizontally and 24 pixels vertically outside of
 the dialog box.

--- a/docs/controls/alertdialog.md
+++ b/docs/controls/alertdialog.md
@@ -79,6 +79,8 @@ Typically this is a list of [`TextButton`](/docs/controls/textbutton) controls.
 
 The padding that surrounds each button in `actions`.
 
+Value is of type `PaddingValue`.
+
 ### `actions_alignment`
 
 Defines the horizontal layout of the actions.
@@ -93,7 +95,7 @@ Typically used to provide padding to the button bar between the button bar and t
 
 If are no actions, then no padding will be included. The padding around the button bar defaults to zero.
 
-The value is an instance of [`padding.Padding`](/docs/reference/types/padding) class or a number.
+The value of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `adaptive`
 
@@ -104,7 +106,7 @@ On iOS and macOS, a [`CupertinoAlertDialog`](/docs/controls/cupertinoalertdialog
 See the example of
 usage [here](/docs/controls/cupertinoalertdialog#cupertinoalertdialog-and-adaptive-alertdialog-example).
 
-Defaults to `False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `bgcolor`
 
@@ -118,7 +120,7 @@ Value is of type [`ClipBehavior`](/docs/reference/types/clipbehavior) and defaul
 
 ### `content`
 
-The (optional) content of the dialog is displayed in the center of the dialog in a lighter font. Typically this is a [`Column`](/docs/controls/column) that contains the dialog's [`Text`](/docs/controls/text) message.
+The (optional) content (of type `Control`) of the dialog is displayed in the center of the dialog in a lighter font. Typically this is a [`Column`](/docs/controls/column) that contains the dialog's [`Text`](/docs/controls/text) message.
 
 ### `content_padding`
 
@@ -126,11 +128,13 @@ Padding around the content.
 
 If there is no content, no padding will be provided. Otherwise, padding of 20 pixels is provided above the content to separate the content from the title, and padding of 24 pixels is provided on the left, right, and bottom to separate the content from the other edges of the dialog.
 
-The value is an instance of [`Padding`](/docs/reference/types/padding) class or a number.
+The value of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `elevation`
 
 Defines the elevation (z-coordinate) at which the dialog should appear.
+
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber).
 
 ### `icon`
 
@@ -140,11 +144,13 @@ A control that is displayed at the top of the dialog. Typically a [`Icon`](/docs
 
 Padding around the `icon`.
 
+Value is of type `PaddingValue`.
+
 ### `inset_padding`
 
 Padding around the Dialog itself.
 
-The value is an instance of [`Padding`](/docs/reference/types/padding) class or a number.
+The value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 Defaults to `padding.symmetric(vertical=40, horizontal=24)` - 40 pixels horizontally and 24 pixels vertically outside of
 the dialog box.
@@ -153,17 +159,21 @@ the dialog box.
 
 Whether dialog can be dismissed/closed by clicking the area outside of it.
 
+Value is of type `bool` and defaults to `False`.
+
 ### `open`
 
 Set to `True` to display a dialog.
 
-Defaults to `False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `semantics_label`
 
 The semantic label of the dialog used by accessibility frameworks to announce screen transitions when the dialog is opened and closed.
 
 In iOS, if this label is not provided, a semantic label will be inferred from the `title` if it is not null.
+
+Value is of type `str` or `None`
 
 ### `shadow_color`
 
@@ -193,10 +203,10 @@ Padding around the title.
 
 If there is no title, no padding will be provided. Otherwise, this padding is used.
 
-The value is an instance of [`padding.Padding`](/docs/reference/types/padding) class or a number.
+The value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 Defaults to providing `24` pixels on the top, left, and right of the title. If the `content` is not `None`, then no
-bottom padding is provided (but see `content_padding`).
+bottom padding is provided (but see [`content_padding`](#content_padding)).
 If it is not set, then an extra `20` pixels of bottom padding is added to separate the title from the actions.
 
 ## Events

--- a/docs/controls/animatedswitcher.md
+++ b/docs/controls/animatedswitcher.md
@@ -80,7 +80,7 @@ Value is of type `int` defaults to `1000` milliseconds.
 
 The duration, in milliseconds, of the transition from the new `content` value to the old one.
 
-Value of type `int` defaults to `1000` milliseconds.
+Value is of type `int` and defaults to `1000` milliseconds.
 
 ### `switch_in_curve`
 

--- a/docs/controls/animatedswitcher.md
+++ b/docs/controls/animatedswitcher.md
@@ -68,17 +68,19 @@ ft.app(target=main)
 The content to display. When the `content` changes, the AnimatedSwitcher will animate the transition from the
 old `content` to the new one.
 
+Value is of type `Control`.
+
 ### `duration`
 
 The duration, in milliseconds, of the transition from the old `content` value to the new one.
 
-Defaults to `1000` milliseconds.
+Value is of type `int` defaults to `1000` milliseconds.
 
 ### `reverse_duration`
 
 The duration, in milliseconds, of the transition from the new `content` value to the old one.
 
-Defaults to `1000` milliseconds.
+Value of type `int` defaults to `1000` milliseconds.
 
 ### `switch_in_curve`
 

--- a/docs/controls/appbar.md
+++ b/docs/controls/appbar.md
@@ -70,13 +70,15 @@ If the value is `True`, an adaptive AppBar is created based on whether the targe
 
 On iOS and macOS, a [`CupertinoAppBar`](/docs/controls/cupertinoappbar) is created, which has matching functionality and presentation as `AppBar`, and the graphics as expected on iOS. On other platforms, a Material AppBar is created.
 
-The default value is `False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `automatically_imply_leading`
 
 Controls whether we should try to imply the leading widget if null.
 
 If `True` and `leading` is null, automatically try to deduce what the leading widget should be. If `False` and `leading` is null, leading space is given to title. If leading widget is not null, this parameter has no effect.
+
+Value is of type `bool`.
 
 ### `bgcolor`
 
@@ -86,11 +88,13 @@ The fill [color](/docs/reference/colors) to use for an AppBar. Default color is 
 
 Whether the title should be centered.
 
-Defaults to `False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `clip_behavior`
 
-The content will be clipped (or not) according to this option. Property value is [`ClipBehavior`](/docs/reference/types/clipbehavior) enum.
+The content will be clipped (or not) according to this option.
+
+Value is of type [`ClipBehavior`](/docs/reference/types/clipbehavior).
 
 ### `color`
 
@@ -102,17 +106,19 @@ The app bar's elevation.
 
 Note: This effect is only visible when using the Material 2 design (`Theme.use_material3=False`).
 
-Defaults to `4`.
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `4`.
 
 ### `elevation_on_scroll`
 
 The elevation to be used if this app bar has something scrolled underneath it.
 
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber).
+
 ### `exclude_header_semantics`
 
 Whether the `title` should be wrapped with header [`Semantics`](/docs/controls/semantics).
 
-Defaults to `False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `force_material_transparency`
 
@@ -120,11 +126,13 @@ Forces the app bar to be transparent (instead of Material's default type).
 
 This will also remove the visual display of `bgcolor` and `elevation`, and affect other characteristics of this app bar.
 
+Value is of type `bool`.
+
 ### `is_secondary`
 
 Whether this app bar is not being displayed at the top of the screen.
 
-Defaults to`False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `leading`
 
@@ -132,11 +140,13 @@ A `Control` to display before the toolbar's title.
 
 Typically the leading control is an [`Icon`](/docs/controls/icon) or an [`IconButton`](/docs/controls/iconbutton).
 
+Value is of type `Control`.
+
 ### `leading_width`
 
 Defines the width of leading control.
 
-Defaults to  `56.0`.
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `56.0`.
 
 ### `shadow_color`
 
@@ -147,6 +157,8 @@ A shadow is only visible and displayed if the `elevation` is greater than zero.
 ### `shape`
 
 The shape of the app bar's Material as well as its shadow.
+
+Value is of type [`OutlinedBorder`](/docs/reference/types/outlinedborder)
 
 ### `surface_tint_color`
 
@@ -160,11 +172,15 @@ The primary `Control` displayed in the app bar. Typically a [`Text`](/docs/contr
 
 **Note** that, if `AppBar.adaptive=True` and the app is opened on an iOS or macOS device, this control will be automatically centered.
 
+Value is of type `Control`.
+
 ### `title_spacing`
 
 The spacing around `title` on the horizontal axis. It is applied even if there are no `leading` or `actions` controls.
 
 If you want `title` to take all the space available, set this value to `0.0`.
+
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber).
 
 ### `title_text_style`
 
@@ -176,11 +192,13 @@ Value is of type [`TextStyle`](/docs/reference/types/textstyle).
 
 Defines the height of the toolbar component of an AppBar.
 
-Defaults to `56.0`.
+Value is of tye [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `56.0`.
 
 ### `toolbar_opacity`
 
-The opacity of the toolbar. Value ranges from `0.0` (transparent) to `1.0` (fully opaque) which is the default.
+The opacity of the toolbar. Value ranges from `0.0` (transparent) to `1.0` (fully opaque).
+
+VAlue is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `1.0`.
 
 ### `toolbar_text_style`
 

--- a/docs/controls/appbar.md
+++ b/docs/controls/appbar.md
@@ -158,7 +158,7 @@ A shadow is only visible and displayed if the `elevation` is greater than zero.
 
 The shape of the app bar's Material as well as its shadow.
 
-Value is of type [`OutlinedBorder`](/docs/reference/types/outlinedborder)
+Value is of type [`OutlinedBorder`](/docs/reference/types/outlinedborder).
 
 ### `surface_tint_color`
 
@@ -198,7 +198,7 @@ Value is of tye [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)
 
 The opacity of the toolbar. Value ranges from `0.0` (transparent) to `1.0` (fully opaque).
 
-VAlue is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `1.0`.
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `1.0`.
 
 ### `toolbar_text_style`
 

--- a/docs/controls/audio.md
+++ b/docs/controls/audio.md
@@ -149,7 +149,7 @@ Setting balance is supported on Windows and Linux only.
 
 Sets the playback rate. iOS and macOS have limits between 0.5 and 2x Android SDK version should be 23 or higher.
 
-Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber).
 
 ### `release_mode`
 
@@ -177,7 +177,7 @@ Sets the volume (amplitude).
 
 0 is mute and 1 is the max volume. The values between 0 and 1 are linearly interpolated.
 
-Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber).
 
 ## Methods
 

--- a/docs/controls/audio.md
+++ b/docs/controls/audio.md
@@ -127,6 +127,8 @@ ft.app(target=main)
 
 Starts playing audio as soon as audio control is added to a page.
 
+Value is of type `bool` and defaults to `False`.
+
 :::note
 Autoplay works in desktop, mobile apps and Safari browser, but doesn't work in Chrome/Edge.
 :::
@@ -137,6 +139,8 @@ Sets the stereo balance.
 
 -1 - The left channel is at full volume; the right channel is silent. 1 - The right channel is at full volume; the left channel is silent. 0 - Both channels are at the same volume.
 
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber).
+
 :::note
 Setting balance is supported on Windows and Linux only.
 :::
@@ -144,6 +148,8 @@ Setting balance is supported on Windows and Linux only.
 ### `playback_rate`
 
 Sets the playback rate. iOS and macOS have limits between 0.5 and 2x Android SDK version should be 23 or higher.
+
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)
 
 ### `release_mode`
 
@@ -163,11 +169,15 @@ Sets the URL to the audio file. It could be an asset URL, see [Image.src](/docs/
 
 Sets the contents of audio file encoded in base-64 format.
 
+Value is of type `str`.
+
 ### `volume`
 
 Sets the volume (amplitude).
 
 0 is mute and 1 is the max volume. The values between 0 and 1 are linearly interpolated.
+
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)
 
 ## Methods
 

--- a/docs/controls/audiorecorder.md
+++ b/docs/controls/audiorecorder.md
@@ -106,7 +106,7 @@ ft.app(target=main)
 Not all properties are supported on all platforms. Please check this [platform-feature parity matrix](https://pub.dev/packages/record#platform-feature-parity-matrix) for more information on which properties are supported on which platforms.
 :::
 
-### `audio_encoding`
+### `audio_encoder`
 
 The audio encoder to be used for recording.
 
@@ -119,19 +119,19 @@ See [`this`](https://pub.dev/packages/record#file) for a detailed overview on th
 
 The recorder will try to auto adjust recording volume in a limited range.
 
-Defaults to `False`.
+Value is of type `bool` and defaults to `False`.
 
 ### `bit_rate`
 
 The audio encoding bit rate in bits per second.
 
-Defaults to `128000`.
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `128000`.
 
 ### `cancel_echo`
 
 The recorder will try to reduce echo.
 
-Defaults to `False`.
+Value is of type `bool` defaults to `False`.
 
 ### `channels_num`
 
@@ -143,13 +143,13 @@ Defaults to `2`.
 
 The sample rate for audio in samples per second.
 
-Defaults to `44100`.
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `44100`.
 
 ### `suppress_noise`
 
 The recorder will try to negates the input noise.
 
-Defaults to `False`.
+Value is of type `bool` and defaults to `False`.
 
 ## Methods
 

--- a/docs/controls/autocomplete.md
+++ b/docs/controls/autocomplete.md
@@ -47,6 +47,8 @@ The index of the selected suggestion in the list of `suggestions`.
 
 This property is read-only and `None` at initialization, until a suggestion is selected for the first time.
 
+Valule is of type `int`.
+
 ### `suggestions`
 
 A list of [`AutoCompleteSuggestion`](/docs/reference/types/autocompletesuggestion) controls representing the suggestions to be displayed. 
@@ -60,7 +62,7 @@ A list of [`AutoCompleteSuggestion`](/docs/reference/types/autocompletesuggestio
 
 The maximum - visual - height of the suggestions list.
 
-Defaults to `200`.
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `200`.
 
 ## Events
 

--- a/docs/controls/autofillgroup.md
+++ b/docs/controls/autofillgroup.md
@@ -65,7 +65,7 @@ ft.app(main)
 
 The content control of this group.
 
-Value is of type `Control`
+Value is of type `Control`.
 
 ### `dispose_action`
 

--- a/docs/controls/autofillgroup.md
+++ b/docs/controls/autofillgroup.md
@@ -65,6 +65,8 @@ ft.app(main)
 
 The content control of this group.
 
+Value is of type `Control`
+
 ### `dispose_action`
 
 The action to be run when this `AutofillGroup` is the topmost `AutofillGroup` and it's being disposed, in order to clean

--- a/docs/controls/badge.md
+++ b/docs/controls/badge.md
@@ -57,7 +57,7 @@ ft.app(target=main)
 
 ### `alignment`
 
-Aligns the label relative to the content of the badge. The value is an instance of [`alignment.Alignment`](/docs/reference/types/alignment) class.
+Aligns the label relative to the content of the badge.
 
 The alignment positions the label in similar way content of a container is positioned using its [`alignment`](/docs/controls/container#alignment), except that the badge alignment is resolved as if the label was a [`large_size`](/docs/controls/badge#large_size) square and `offset` is added to the result.
 
@@ -68,23 +68,32 @@ For example:
 ```python
 badge.alignment = ft.alignment.top_left
 ```
+
+The value is of type [`Alignment`](/docs/reference/types/alignment)
+
 ### `bgcolor`
 
 Background [color](/docs/reference/colors) of the label.
 
 ### `content`
 
-A child Control contained by the badge, typically an icon that's part of a [`NavigationBar`](/docs/controls/navigationbar) or a [`NavigationRail`](/docs/controls/navigationrail) destination.
+A child `Control` contained by the badge, typically an icon that's part of a [`NavigationBar`](/docs/controls/navigationbar) or a [`NavigationRail`](/docs/controls/navigationrail) destination.
+
+Value is of type `Control`.
 
 ### `label_visible`
 
 If False, label is not displayed. By default, `label_visible` is True. It can be used to create a badge that's only shown under certain conditions.
 
+Valeu is of type `bool`.
+
 ### `large_size`
 
 The badge's label height if `text` is provided.
 
-Default value is 16. If the default value is overridden then it may be useful to also override `padding` and `alignment`.
+If the default value is overridden then it may be useful to also override `padding` and `alignment`.
+
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)  and default value is 16. 
 
 ### `offset`
 
@@ -92,7 +101,7 @@ Combined with `alignment` to determine the location of the label relative to the
 
 Has effect only used if `text` is also provided.
 
-Value is of type [`Offset`](/docs/controls#offset) for possible values.
+Value is of type [`OffsetValue`](/docs/reference/types/aliases#offsetvalue).
 
 ### `padding`
 
@@ -100,13 +109,13 @@ The padding added to the badge's label.
 
 This value is only used if `text` is provided. Defaults to 4 pixels on the left and right.
 
-Padding value is an instance of [`Padding`](/docs/reference/types/padding) class.
+Padding value is an instance of [`PaddingValue`](/docs/reference/types/aliases#paddingvalue)
 
 ### `small_size`
 
 The badge's label diameter if `text` is not provided.
 
-Default value is 6.
+Vaue is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber) and defaults to `6`.
 
 ### `text`
 
@@ -116,6 +125,8 @@ If the text is not provided, the badge is shown as a filled circle of [`small_si
 
 If `text` is provided, the label is a StadiumBorder shaped badge with height equal to [`large_size`](#large_size).
 
+Value is of type `str`
+
 ### `text_color`
 
 [Color](/docs/reference/colors) of the text shown in the label. This color overrides the color of the label's `text_style`.
@@ -123,6 +134,3 @@ If `text` is provided, the label is a StadiumBorder shaped badge with height equ
 ### `text_style`
 
 The text style to use for text in the label. The value is an instance if [`TextStyle`](/docs/reference/types/textstyle) class.
-
-
-

--- a/docs/controls/badge.md
+++ b/docs/controls/badge.md
@@ -69,7 +69,7 @@ For example:
 badge.alignment = ft.alignment.top_left
 ```
 
-The value is of type [`Alignment`](/docs/reference/types/alignment)
+Value is of type [`Alignment`](/docs/reference/types/alignment).
 
 ### `bgcolor`
 
@@ -85,7 +85,7 @@ Value is of type `Control`.
 
 If False, label is not displayed. By default, `label_visible` is True. It can be used to create a badge that's only shown under certain conditions.
 
-Valeu is of type `bool`.
+Value is of type `bool`.
 
 ### `large_size`
 
@@ -93,7 +93,7 @@ The badge's label height if `text` is provided.
 
 If the default value is overridden then it may be useful to also override `padding` and `alignment`.
 
-Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)  and default value is 16. 
+Value is of type [`OptionalNumber`](/docs/reference/types/aliases#optionalnumber)  and defaults to `16`. 
 
 ### `offset`
 
@@ -109,7 +109,7 @@ The padding added to the badge's label.
 
 This value is only used if `text` is provided. Defaults to 4 pixels on the left and right.
 
-Padding value is an instance of [`PaddingValue`](/docs/reference/types/aliases#paddingvalue)
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue).
 
 ### `small_size`
 
@@ -125,7 +125,7 @@ If the text is not provided, the badge is shown as a filled circle of [`small_si
 
 If `text` is provided, the label is a StadiumBorder shaped badge with height equal to [`large_size`](#large_size).
 
-Value is of type `str`
+Value is of type `str`.
 
 ### `text_color`
 
@@ -133,4 +133,6 @@ Value is of type `str`
 
 ### `text_style`
 
-The text style to use for text in the label. The value is an instance if [`TextStyle`](/docs/reference/types/textstyle) class.
+The text style to use for text in the label.
+
+Value is of type [`TextStyle`](/docs/reference/types/textstyle).

--- a/docs/controls/view.md
+++ b/docs/controls/view.md
@@ -125,9 +125,7 @@ Value is of type `str`
 
 Enables a vertical scrolling for the Page to prevent its content overflow.
 
-Property value is an optional [`ScrollMode`](/docs/reference/types/scrollmode) enum with `None` as default.
-
-Value is of type [`ScrollMode`](/docs/reference/types/scrollmode) and defaults to `None`.
+Value is of type [`ScrollMode`](/docs/reference/types/scrollmode).
 
 ### `spacing`
 

--- a/docs/controls/view.md
+++ b/docs/controls/view.md
@@ -86,7 +86,7 @@ A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to displ
 
 Describes position of [`floating_action_button`](#floating_action_button)
 
-Value is of type [`FloatingActionButtonLocaiton`](/docs/controls/floatingactionbutton)
+Value is of type [`FloatingActionButtonLocation`](/docs/controls/floatingactionbutton)
 
 ### `fullscreen_dialog`
 

--- a/docs/controls/view.md
+++ b/docs/controls/view.md
@@ -105,13 +105,15 @@ to `CrossAxisAlignment.START`.
 
 ### `on_scroll_interval`
 
-Throttling in milliseconds for `on_scroll` event. Value is of type `int` and defaults to `10`.
+Throttling in milliseconds for `on_scroll` event.
+
+Value is of type `int` and defaults to `10`.
 
 ### `padding`
 
 A space between page contents and its edges.
 
-Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue) and defaults to `10`.
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue) and defaults to `padding.all(10)`.
 
 ### `route`
 
@@ -125,7 +127,7 @@ Enables a vertical scrolling for the Page to prevent its content overflow.
 
 Property value is an optional [`ScrollMode`](/docs/reference/types/scrollmode) enum with `None` as default.
 
-Value is of type [`ScrollMode`](/docs/reference/types/scrollmode) and defaults to `ScrollMode.None`
+Value is of type [`ScrollMode`](/docs/reference/types/scrollmode) and defaults to `None`.
 
 ### `spacing`
 

--- a/docs/controls/view.md
+++ b/docs/controls/view.md
@@ -28,7 +28,7 @@ Background [color](/docs/reference/colors) of the view.
 
 ### `controls`
 
-A list of Controls to display on the Page.
+A list of `Control`s to display on the Page.
 
 For example, to add a new control to a page:
 
@@ -68,6 +68,8 @@ page.update()
   </TabItem>
 </Tabs>
 
+Value is of a list of `Control`s
+
 ### `drawer`
 
 A [`NavigationDrawer`](/docs/controls/navigationdrawer) control to display as a panel sliding from the start edge of the view.
@@ -76,19 +78,23 @@ A [`NavigationDrawer`](/docs/controls/navigationdrawer) control to display as a 
 
 A [`NavigationDrawer`](/docs/controls/navigationdrawer) control to display as a panel sliding from the end edge of the view.
 
+### `floating_action_button`
+
+A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to display on top of Page content.
+
+### `floating_action_button_location`
+
+Describes position of [`floating_action_button`](#floating_action_button)
+
+Value is of type [`FloatingActionButtonLocaiton`](/docs/controls/floatingactionbutton)
+
 ### `fullscreen_dialog`
 
 Whether this view is a full-screen dialog.
 
 In Material and Cupertino, being fullscreen has the effects of making the app bars have a close button instead of a back button. On iOS, dialogs transitions animate differently and are also not closeable with the back swipe gesture.
 
-### `route`
-
-View's route - not currently used by Flet framework, but can be used in a user program to update [`page.route`](/docs/controls/page#route) when a view popped.
-
-### `floating_action_button`
-
-A [`FloatingActionButton`](/docs/controls/floatingactionbutton) control to display on top of Page content.
+Value is of type `bool` and defaults to `False`.
 
 ### `horizontal_alignment`
 
@@ -99,13 +105,19 @@ to `CrossAxisAlignment.START`.
 
 ### `on_scroll_interval`
 
-Throttling in milliseconds for `on_scroll` event. Default is `10`.
+Throttling in milliseconds for `on_scroll` event. Value is of type `int` and defaults to `10`.
 
 ### `padding`
 
-A space between page contents and its edges. Default value is 10 pixels from each side.
+A space between page contents and its edges.
 
-Padding is an instance of [`padding.Padding`](/docs/reference/types/padding) class.
+Value is of type [`PaddingValue`](/docs/reference/types/aliases#paddingvalue) and defaults to `10`.
+
+### `route`
+
+View's route - not currently used by Flet framework, but can be used in a user program to update [`page.route`](/docs/controls/page#route) when a view popped.
+
+Value is of type `str`
 
 ### `scroll`
 
@@ -113,10 +125,14 @@ Enables a vertical scrolling for the Page to prevent its content overflow.
 
 Property value is an optional [`ScrollMode`](/docs/reference/types/scrollmode) enum with `None` as default.
 
+Value is of type [`ScrollMode`](/docs/reference/types/scrollmode) and defaults to `ScrollMode.None`
+
 ### `spacing`
 
 Vertical spacing between controls on the Page. Default value is 10 virtual pixels. Spacing is applied only
 when `vertical_alignment` is set to `MainAxisAlignment.START`, `MainAxisAlignment.END` or `MainAxisAlignment.CENTER`.
+
+Value is of type [`OptionalNumber`] and defaults to `10`
 
 ### `vertical_alignment`
 

--- a/docs/controls/webview.md
+++ b/docs/controls/webview.md
@@ -48,13 +48,19 @@ Set the background [color](/docs/reference/colors) of the WebView.
 
 Enable or disable the JavaScript execution on the page. Note, that disabling the JavaScript execution on the page may result to unexpected web page behaviour.
 
+Value is of type `bool`
+
 ### `prevent_link`
 
 Specify a prefix for links to prevent navigating or downloading.
 
+Value is of type `str`
+
 ### `url`
 
 Start the WebView by loading the `url` value.
+
+Value is of type `str`
 
 ## Events
 

--- a/docs/controls/webview.md
+++ b/docs/controls/webview.md
@@ -48,19 +48,19 @@ Set the background [color](/docs/reference/colors) of the WebView.
 
 Enable or disable the JavaScript execution on the page. Note, that disabling the JavaScript execution on the page may result to unexpected web page behaviour.
 
-Value is of type `bool`
+Value is of type `bool`.
 
 ### `prevent_link`
 
 Specify a prefix for links to prevent navigating or downloading.
 
-Value is of type `str`
+Value is of type `str`.
 
 ### `url`
 
 Start the WebView by loading the `url` value.
 
-Value is of type `str`
+Value is of type `str`.
 
 ## Events
 

--- a/docs/controls/windowdragarea.md
+++ b/docs/controls/windowdragarea.md
@@ -47,8 +47,10 @@ ft.app(target=main)
 
 A control to use for dragging/maximizing/restoring app window.
 
+Value is of type `Control`.
+
 ### `maximizable`
 
 Whether double-clicking on a window drag area causes window to maximize/restore.
 
-Defaults to `True`.
+Value is of type `bool` and defaults to `True`.


### PR DESCRIPTION
Add types and default values references for `AlertDialog`, `AnimatedSwitcher`, `AppBar`, `Audio`, `AudioRecorder`, `AutoComplete`, `AutoFillGroup`, `Badge`, `View`, `WebView` and `WindowDragArea` controls.