### PR TITLE
Update docs/controls/page.md.

### DIFF
--- a/docs/controls/page.md
+++ b/docs/controls/page.md
@@ -990,19 +990,16 @@ def main(page: ft.Page):
 
     def window_event(e):
         if e.data == "close":
-            page.dialog = confirm_dialog
-            confirm_dialog.open = True
-            page.update()
+            page.open(confirm_dialog)
 
     page.window.prevent_close = True
-    page.on_window_event = window_event
+    page.window.on_event = window_event
 
     def yes_click(e):
         page.window.destroy()
 
     def no_click(e):
-        confirm_dialog.open = False
-        page.update()
+        page.close(confirm_dialog)
 
     confirm_dialog = ft.AlertDialog(
         modal=True,


### PR DESCRIPTION
+ Changed window's **on_event** method to newer version `page.window.on_event` (Deprecated in v0.23.0 and will be removed in v0.26.0. Use [Page.window.on_event()](https://flet.dev/docs/controls/page#window) instead.)
+ Changed `window_event` function to **open** control instead of setting it's open property to True and updating it. (`page.open(confirm_dialog)`)
+ Changed `no_click` function to **close** control instead of setting it's property to False and updating it. (`page.close(confirm_dialog)`)