### PR TITLE
WSL Ubuntu 24.04.1 LTS Notes fix

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -107,3 +107,19 @@ Now you are ready to [create your first Flet app](create-flet-app).
 When [creating](create-flet-app) and [running](running-app) Flet app using Poetry, you'll need to use `poetry run` before each command!
 :::
 
+:::Windows WSL Installs
+if you recieve `error while loading shared libraries: libgstapp-1.0.so.0` g-streamer is not included in the Ubuntu 24.04.1 LTS
+```apt install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools```
+will install gstreamer for flet.
+
+you will then recieve another error `error while loading shared libraries: libmpv.so.1: cannot open shared object file: No such file or directory`
+```
+sudo apt update
+
+sudo apt install libmpv-dev libmpv2
+
+sudo ln -s /usr/lib/x86_64-linux-gnu/libmpv.so /usr/lib/libmpv.so.1
+```
+
+Fixes the isse 
+::: 


### PR DESCRIPTION
Fix for fresh install of wsl ubuntu to run flet

Windows WSL Installs
if you recieve `error while loading shared libraries: libgstapp-1.0.so.0` g-streamer is not included in the Ubuntu 24.04.1 LTS

```apt install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools```

will install gstreamer for flet.

you will then recieve another error

 `error while loading shared libraries: libmpv.so.1: cannot open shared object file: No such file or directory`

```
sudo apt update
sudo apt install libmpv-dev libmpv2
sudo ln -s /usr/lib/x86_64-linux-gnu/libmpv.so /usr/lib/libmpv.so.1
```

Fixes the isse 
::: 

![image](https://github.com/user-attachments/assets/8bb97a5a-c3c5-4914-880c-4acca0ab9d02)
