### PR TITLE
Update create-flet-app.md

### DIFF
--- a/docs/getting-started/create-flet-app.md
+++ b/docs/getting-started/create-flet-app.md
@@ -42,7 +42,9 @@ The command will create the following directory structure:
 ```
 
 :::note
-Original `pyproject.toml` created by `uv init` or `poetry init` will be replaced with the one from Flet app template.
+1. Original `pyproject.toml` created by `uv init` or `poetry init` will be replaced with the one from Flet app template.
+2. In case you encounter the error `Error creating the project from a template: 'git' is not installed.`, it means that you don't have _Git_ installed. Please visit [git-scm.com/downloads](https://git-scm.com/downloads) and install the latest version of _Git_. To verify your installation, type ‘git’ on Command Prompt.
+Please note that _Git_ is not the same as _GitHub CLI_ which is not an alternative for use with Flet.
 :::
 
 `src/main.py` contains Flet program. It has `main()` function where you would add UI elements ([controls](flet-controls)) to a page or a window. The application ends with a blocking `ft.app()` function which initializes Flet app and [runs](running-app) `main()`.

--- a/docs/getting-started/create-flet-app.md
+++ b/docs/getting-started/create-flet-app.md
@@ -43,7 +43,7 @@ The command will create the following directory structure:
 
 :::note
 1. Original `pyproject.toml` created by `uv init` or `poetry init` will be replaced with the one from Flet app template.
-2. In case you encounter the error `Error creating the project from a template: 'git' is not installed.`, it means that you don't have _Git_ installed. Please visit [git-scm.com/downloads](https://git-scm.com/downloads) and install the latest version of _Git_. To verify your installation, type ‘git’ on Command Prompt.
+2. In case you encounter the error `Error creating the project from a template: 'git' is not installed.`, it means that you don't have _Git_ installed. Please visit [git-scm.com/downloads](https://git-scm.com/downloads) and install the latest version of _Git_. To verify your installation, type `git` in the terminal.
 Please note that _Git_ is not the same as _GitHub CLI_ which is not an alternative for use with Flet.
 :::
 


### PR DESCRIPTION
Added troubleshooting information for users in case they encounter error: Git not installed. This is important because the link to installing Git is provided as well as information so users don't confuse Git with GitHub.