### PR TITLE
Remove duplicate property mention

### DIFF
--- a/docs/controls/image.md
+++ b/docs/controls/image.md
@@ -169,10 +169,6 @@ How to paint any portions of the layout bounds not covered by the image.
 
 Values is of type [`ImageRepeat`](/docs/reference/types/imagerepeat) and defaults to `ImageRepeat.NO_REPEAT`.
 
-### `semantics_label`
-
-A semantics label for this image.
-
 ### `tooltip`
 
 The text displayed when hovering a mouse over the Image.


### PR DESCRIPTION
semantics_label was mentioned twice in the docs for Image control. Removed the more vague one, and preserved the one with more information, which still covers the description of the duplicate.