### PR TITLE
fix: correct label typo from 'Blusky' to 'Bluesky'

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,7 +118,7 @@ module.exports = {
               href: 'https://x.com/fletdev',
             },
             {
-              label: 'Blusky',
+              label: 'Bluesky',
               href: 'https://bsky.app/profile/fletdev.bsky.social',
             },
           ],


### PR DESCRIPTION
Corrected the typo in the text from "Blusky" to "Bluesky" in the file docusaurus.config.js

![image](https://github.com/user-attachments/assets/1528a4f4-f418-483a-b1c8-522cb2d3cb9f)
