### PR TITLE
Update geolocator.md

### DIFF
--- a/docs/controls/geolocator.md
+++ b/docs/controls/geolocator.md
@@ -9,10 +9,10 @@ Based on the [geolocator](https://pub.dev/packages/geolocator) Dart/Flutter pack
 Geolocator control is non-visual and should be added to `page.overlay` list.
 
 :::info Packaging
-To build your Flet app that uses `Geolocator` control add `--include-packages flet_geolocator` to `flet build` command, for example:
+To build your Flet app that uses `Geolocator` control add `--permissions location` to `flet build` command, for example:
 
 ```
-flet build apk --include-packages flet_geolocator
+flet build apk --permissions location
 ```
 :::
 


### PR DESCRIPTION
--include-packages was deprecated in the 0.26.0 release. the  --permissions argument took its place.