### PR TITLE
The docs recommends “horizontal” parameter for a vertical margin

### DIFF
--- a/docs/reference/types/padding.md
+++ b/docs/reference/types/padding.md
@@ -47,7 +47,7 @@ Applies padding to the specified sides.
 ```python
 container_1.padding = ft.padding.all(10)
 container_2.padding = 20 # same as ft.padding.all(20)
-container_3.padding = ft.padding.symmetric(horizontal=10)
+container_3.padding = ft.padding.symmetric(vertical=10)
 container_4.padding=padding.only(left=10)
 ```
 


### PR DESCRIPTION
Hello, maybe I'm wrong but the horizontal margin is the left/right margin and not the top/bottom margin (when I test it I have to put vertical to reproduce the example in the image).