### PR TITLE
Depreciated docs on the flet-fastapi library

### DIFF
--- a/blog/2023-08-30-flet-for-fastapi.md
+++ b/blog/2023-08-30-flet-for-fastapi.md
@@ -19,7 +19,7 @@ On the other hand, seasoned FastAPI developers can use Flet to easily add intera
 
 ```python
 import flet as ft
-import flet_fastapi
+import flet.fastapi as flet_fastapi
 
 async def main(page: ft.Page):
     await page.add_async(
@@ -34,7 +34,7 @@ It's a simple app that just outputs "Hello, Flet!" on a web page.
 To run the app install Flet for FastAPI and Uvicorn:
 
 ```
-pip install flet-fastapi
+pip install flet
 pip install uvicorn
 ```
 


### PR DESCRIPTION
Hello, while looking for how to set up a FastAPI for file upload in web app mode, I came across this page which is no longer up to date (first result on the search engine by typing “flet fastapi”).

I finally found this article that explains how to use Flet with FastAPI: 
https://flet.dev/blog/flet-fastapi-and-async-api-improvements/#:~:text=package%20has%20been-,deprecated,-and%20its%20contents