### PR TITLE
Update file-picker-and-uploads.md

### DIFF
--- a/docs/cookbook/file-picker-and-uploads.md
+++ b/docs/cookbook/file-picker-and-uploads.md
@@ -61,13 +61,11 @@ When dialog is closed `FilePicker.on_result` event handler is called which event
 * `path` - "Save file" and "Get directory" dialogs, a full path to a file or directory or `None` if dialog was cancelled.
 
 ```python
-import flet as ft
-
 def on_dialog_result(e: ft.FilePickerResultEvent):
     print("Selected files:", e.files)
     print("Selected file or directory:", e.path)
 
-file_picker = ft.FilePicker(on_result=on_dialog_result)
+selected_file = file_picker.on_result=file_selection
 ```
 
 The last result is always available in `FilePicker.result` property.


### PR DESCRIPTION
I made changes to the code of the section which explains the FilePicker.on_result event handler as the code does not follow in continuity with the previous two sections. This causes the an error when all three section of the code combined while running the program. The error stems from the line file_picker = ft.FilePicker(on_result=file_selection) as the file_picker = ft.FilePicker() is already defined in the first section